### PR TITLE
improvement: Add typespecs for `Spark.Dsl.Entity` and `Spark.Dsl.Section`.

### DIFF
--- a/lib/spark/dsl/entity.ex
+++ b/lib/spark/dsl/entity.ex
@@ -52,6 +52,31 @@ defmodule Spark.Dsl.Entity do
     docs: ""
   ]
 
+  alias Spark.{
+    Dsl.Entity,
+    OptionsHelpers
+  }
+
+  @type t :: %Entity{
+          name: atom,
+          target: module,
+          transform: mfa,
+          recursive_as: atom,
+          examples: [String.t()],
+          entities: [t],
+          deprecations: [{atom, String.t()}],
+          describe: String.t(),
+          snippet: String.t(),
+          args: [atom],
+          links: [{atom, [String.t()]}],
+          hide: boolean,
+          modules: [String.t()],
+          no_depend_modules: [atom],
+          schema: OptionsHelpers.schema(),
+          auto_set_fields: [{atom, any}],
+          docs: String.t()
+        }
+
   def build(
         %{target: target, schema: schema, auto_set_fields: auto_set_fields, transform: transform},
         opts,
@@ -61,7 +86,7 @@ defmodule Spark.Dsl.Entity do
       Keyword.split(auto_set_fields || [], Keyword.keys(schema))
 
     with {:ok, opts} <-
-           Spark.OptionsHelpers.validate(Keyword.merge(opts || [], before_validate_auto), schema),
+           OptionsHelpers.validate(Keyword.merge(opts || [], before_validate_auto), schema),
          opts <- Keyword.merge(opts, after_validate_auto),
          opts <- Enum.map(opts, fn {key, value} -> {schema[key][:as] || key, value} end),
          built <- struct(target, opts),

--- a/lib/spark/dsl/section.ex
+++ b/lib/spark/dsl/section.ex
@@ -36,4 +36,25 @@ defmodule Spark.Dsl.Section do
     sections: [],
     docs: ""
   ]
+
+  alias Spark.{
+    Dsl.Entity,
+    Dsl.Section,
+    OptionsHelpers
+  }
+
+  @type t :: %Section{
+          name: atom,
+          imports: [module],
+          schema: [OptionsHelpers.schema()],
+          describe: String.t(),
+          snippet: String.t(),
+          links: [{atom, [String.t()]}],
+          examples: [String.t()],
+          no_depend_modules: [atom],
+          auto_set_fields: [{atom, any}],
+          entities: [Entity.t()],
+          sections: [Section.t()],
+          docs: String.t()
+        }
 end

--- a/lib/spark/options_helpers.ex
+++ b/lib/spark/options_helpers.ex
@@ -32,7 +32,7 @@ defmodule Spark.OptionsHelpers do
           | {:spark_behaviour, module, module}
           | {:spark_function_behaviour, module, {module, integer}}
           | {:spark_function_behaviour, module, module, {module, integer}}
-          | {:behavior, module}
+          | {:behaviour, module}
           | {:spark, module}
           | {:mfa_or_fun, non_neg_integer()}
           | {:spark_type, module, builtin_function :: atom}


### PR DESCRIPTION
Closes #8.