### PR TITLE
Apply auto_set_fields when building entities in a transformer

### DIFF
--- a/test/transfomer_test.exs
+++ b/test/transfomer_test.exs
@@ -1,0 +1,42 @@
+defmodule TransfomerTest do
+  use ExUnit.Case
+
+  test "build_entity respects auto_set_fields" do
+    defmodule Entity do
+      defstruct [:set_automatically, :set_manually]
+    end
+
+    defmodule Dsl do
+      @entity %Spark.Dsl.Entity{
+        name: :entity,
+        target: Entity,
+        schema: [
+          set_automatically: [
+            type: :boolean
+          ],
+          set_manually: [
+            type: :boolean
+          ]
+        ],
+        auto_set_fields: [set_automatically: true]
+      }
+
+      @section %Spark.Dsl.Section{
+        name: :section,
+        entities: [
+          @entity
+        ]
+      }
+
+      use Spark.Dsl.Extension, sections: [@section]
+      use Spark.Dsl, default_extensions: [extensions: Dsl]
+    end
+
+    {:ok, entity} = Spark.Dsl.Transformer.build_entity(Dsl, [:section], :entity, [])
+
+    IO.inspect(entity)
+
+    assert entity.set_automatically == true
+    assert entity.set_manually == nil
+  end
+end


### PR DESCRIPTION
I mostly copied the code from here https://github.com/ash-project/spark/blob/66250ad02eb74b309171795499de7c22fe9c44e9/lib/spark/dsl/entity.ex#L80

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
