### PR TITLE
Support multiple function clauses in anonymous functions

### DIFF
--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -41,6 +41,32 @@ defmodule Spark.DslTest do
                "Help me Obi-Wan Kenobi: you're my only hope."
     end
 
+    test "supports multiple function clauses" do
+      defmodule Prequel do
+        use Spark.Test.Contact
+
+        contact do
+          contacter(fn
+            "Hello there" ->
+              "General Kenobi"
+
+            "A surprise to be sure" ->
+              "But a welcome one"
+
+            "This is outrageous" ->
+              "It's unfair"
+          end)
+        end
+      end
+
+      assert {Spark.Test.Contact.Contacter.Function, opts} =
+               Spark.Test.Contact.Info.contacter(Prequel)
+
+      assert opts[:fun].("Hello there") == "General Kenobi"
+      assert opts[:fun].("A surprise to be sure") == "But a welcome one"
+      assert opts[:fun].("This is outrageous") == "It's unfair"
+    end
+
     test "entities support functions in option setters" do
       defmodule PaulMcCartney do
         use Spark.Test.Contact


### PR DESCRIPTION
This adds support for anymous functions with multiple clauses.

Before this change, this code would fail to compile:

```
argument fn
  "foo" -> "bar"
  _ -> "default"
end
```

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
