### PR TITLE
fix: Make sections explicitly patchable, improve info generator.

### DIFF
--- a/lib/spark/dsl/section.ex
+++ b/lib/spark/dsl/section.ex
@@ -34,7 +34,8 @@ defmodule Spark.Dsl.Section do
     deprecations: [],
     entities: [],
     sections: [],
-    docs: ""
+    docs: "",
+    patchable?: false
   ]
 
   alias Spark.{
@@ -56,6 +57,7 @@ defmodule Spark.Dsl.Section do
           auto_set_fields: Keyword.t(any),
           entities: [Entity.t()],
           sections: [Section.t()],
-          docs: String.t()
+          docs: String.t(),
+          patchable?: boolean
         }
 end

--- a/lib/spark/info_generator.ex
+++ b/lib/spark/info_generator.ex
@@ -86,7 +86,7 @@ defmodule Spark.InfoGenerator do
       extension.sections()
       |> Stream.filter(&(&1.name in sections))
       |> Stream.flat_map(&explode_section([], &1))
-      |> Stream.filter(fn {_, section} -> Enum.any?(section.entities) end)
+      |> Stream.filter(fn {_, section} -> section.patchable? || Enum.any?(section.entities) end)
       |> Stream.map(&elem(&1, 0))
 
     for path <- entity_paths do

--- a/test/support/contact.ex
+++ b/test/support/contact.ex
@@ -122,6 +122,7 @@ defmodule Spark.Test.Contact do
 
     @presets %Spark.Dsl.Section{
       name: :presets,
+      patchable?: true,
       entities: [
         @preset,
         @preset_with_fn_arg,


### PR DESCRIPTION
By default the `InfoGenerator` will not generate entity functions for sections with no entities. Now that sections can be marked as patchable the info generator can still generate entity functions in those cases.
