### PR TITLE
improvement: evaluate `Transformer.eval` chunks in the order they're added.

### DIFF
--- a/lib/spark/dsl.ex
+++ b/lib/spark/dsl.ex
@@ -368,7 +368,7 @@ defmodule Spark.Dsl do
 
         Spark.Dsl.Extension.set_state(@persist)
 
-        for {block, bindings} <- @spark_dsl_config[:eval] || [] do
+        for {block, bindings} <- Enum.reverse(@spark_dsl_config[:eval] || []) do
           Code.eval_quoted(block, bindings, __ENV__)
         end
 


### PR DESCRIPTION
Just a tiny DX improvement because it violated the principal of least surprise for me.