### PR TITLE
improvement: Make generated __using__/1 overridable for Dsls.

### DIFF
--- a/lib/spark/dsl.ex
+++ b/lib/spark/dsl.ex
@@ -138,8 +138,6 @@ defmodule Spark.Dsl do
         end
       end
 
-      defoverridable init: 1, handle_opts: 1, handle_before_compile: 1, explain: 2
-
       defmacro __using__(opts) do
         parent = unquote(parent)
         parent_opts = unquote(parent_opts)
@@ -260,6 +258,8 @@ defmodule Spark.Dsl do
         preparations = Spark.Dsl.Extension.prepare(extensions)
         [body | preparations]
       end
+
+      defoverridable init: 1, handle_opts: 1, handle_before_compile: 1, explain: 2, __using__: 1
     end
   end
 

--- a/test/support/contact.ex
+++ b/test/support/contact.ex
@@ -150,6 +150,10 @@ defmodule Spark.Test.Contact do
 
   use Spark.Dsl, default_extensions: [extensions: Dsl]
 
+  defmacro __using__(opts) do
+    super(opts)
+  end
+
   def explain(_dsl_state, _opts) do
     "Here is an explanation"
   end


### PR DESCRIPTION
This change fixes some DX problems I'm running up against in Cinder.  Also gives some control of the generated module back to the Dsl author.