### PR TITLE
fix: Relax nimble_options dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -115,7 +115,7 @@ defmodule Spark.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:nimble_options, "~> 1.0"},
+      {:nimble_options, "~> 0.5 or ~> 1.0"},
       {:sourceror, "~> 0.1"},
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}


### PR DESCRIPTION
1.0 was only released 2 weeks ago and many libraries haven't updated to it. Since there's no breaking changes in 1.0 supporting both for now shouldn't cause an issue and will make spark easier to add in other projects.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
