### PR TITLE
fix: swap `Exception.exception?` for `Kernel.is_exception`

### DIFF
--- a/lib/spark/dsl.ex
+++ b/lib/spark/dsl.ex
@@ -279,7 +279,7 @@ defmodule Spark.Dsl do
                         |> Enum.each(&IO.warn(&1, Macro.Env.stacktrace(__ENV__)))
 
                       {:error, error} ->
-                        if Exception.exception?(error) do
+                        if is_exception(error) do
                           raise error
                         else
                           raise "Verification error from #{inspect(verifier)}: #{inspect(error)}"
@@ -407,7 +407,7 @@ defmodule Spark.Dsl do
                   |> Enum.each(&IO.warn(&1, Macro.Env.stacktrace(__ENV__)))
 
                 {:error, error} ->
-                  if Exception.exception?(error) do
+                  if is_exception(error) do
                     raise error
                   else
                     raise "Verification error from #{inspect(verifier)}: #{inspect(error)}"

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -704,7 +704,7 @@ defmodule Spark.Dsl.Extension do
   end
 
   defp raise_transformer_error(transformer, error) do
-    if Exception.exception?(error) do
+    if is_exception(error) do
       raise error
     else
       raise "Error while running transformer #{inspect(transformer)}: #{inspect(error)}"
@@ -1630,7 +1630,7 @@ defmodule Spark.Dsl.Extension do
 
                           message =
                             cond do
-                              Exception.exception?(error) ->
+                              is_exception(error) ->
                                 Exception.message(error)
 
                               is_binary(error) ->


### PR DESCRIPTION
`Exception.exception?` [is deprecated](https://hexdocs.pm/elixir/1.12/Exception.html#exception?/1) and [will be removed in elixir 1.15](https://github.com/elixir-lang/elixir/blob/a64d42f5d3cb6c32752af9d3312897e8cd5bb7ec/lib/elixir/lib/exception.ex#L49)

`Kernel.is_exception` has been available [since elixir 1.11](https://hexdocs.pm/elixir/1.14/Kernel.html#is_exception/1), and [since spark requires elixir ~> 1.13](https://github.com/ash-project/spark/blob/main/mix.exs#L12) we are safe to depend on it.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
