### PR TITLE
fix(Entity): don't ever use `Map.put/3` to set an entity's `__identifier__`.

### DIFF
--- a/lib/spark/dsl/entity.ex
+++ b/lib/spark/dsl/entity.ex
@@ -149,7 +149,7 @@ defmodule Spark.Dsl.Entity do
   entity :positional_argument do
     other :other_argument
   end
-  ``` 
+  ```
   """
   @type args :: [atom | {:optional, atom} | {:optional, atom, any}]
 
@@ -252,12 +252,10 @@ defmodule Spark.Dsl.Entity do
           {:ok, built}
 
         {:auto, :unique_integer} ->
-          require_identifier!(built, identifier)
-          {:ok, Map.put(built, :__identifier__, identifier)}
+          {:ok, require_identifier!(built, identifier)}
 
         name ->
-          require_identifier!(built, identifier)
-          {:ok, Map.put(built, :__identifier__, Map.get(built, name))}
+          {:ok, require_identifier!(built, Map.get(built, name))}
       end
     end
   end

--- a/lib/spark/dsl/transformer.ex
+++ b/lib/spark/dsl/transformer.ex
@@ -197,7 +197,7 @@ defmodule Spark.Dsl.Transformer do
               System.unique_integer()
             end
 
-          {:ok, Map.put(built, :__identifier__, identifier)}
+          {:ok, %{built | __identifier__: identifier}}
 
         other ->
           other

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -3,7 +3,7 @@ defmodule TransfomerTest do
 
   test "build_entity respects auto_set_fields" do
     defmodule Entity do
-      defstruct [:set_automatically, :set_manually]
+      defstruct [:set_automatically, :set_manually, :__identifier__]
     end
 
     defmodule Dsl do


### PR DESCRIPTION
Entities without an `__identifier__` field should cause Spark to fail rather than silently break the target struct's contracts.