### PR TITLE
improvement: allow `Patch.AddEntity` if a same-target entity exists

### DIFF
--- a/test/support/contact/contact.ex
+++ b/test/support/contact/contact.ex
@@ -159,7 +159,6 @@ defmodule Spark.Test.Contact do
 
     @presets %Spark.Dsl.Section{
       name: :presets,
-      patchable?: true,
       entities: [
         @preset,
         @preset_with_fn_arg,


### PR DESCRIPTION
The idea is to open up patching possibilities. Right now unless a section explicitly sets `patchable?: true` it is forbidden to add any entities with patches to it.

This change allows adding entities that have the same target as at least one of preexisting entities in a section.

It will allow to easily provide shortcut/alias entities with extensions in ash-compatible way, so that auto-complete and `do end` syntax for options can work out of box for those aliases.

`patchable?: true` still needs to be set to allow adding entities with arbitrary targets.

Don't know if I can put check mark on unit tests, but the only place in tests where `patchable?: true` was used can now omit that option since a test extension was adding the same target thing (preset).

# Contributor checklist

- [ ] Features include unit/acceptance tests