### PR TITLE
fix: code highlight error

### DIFF
--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -10,9 +10,9 @@ defmodule Spark.Dsl.Extension do
   The example at the bottom shows how you might build a (not very contextually
   relevant) DSL extension that would be used like so:
 
-     defmodule MyApp.Vehicle do
+      defmodule MyApp.Vehicle do
         use Spark.Dsl
-     end
+      end
 
       defmodule MyApp.MyResource do
         use MyApp.Vehicle,


### PR DESCRIPTION
# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I don't know if this is intentional but the latest version of the documentation of spark in the Dsl.Extensions page is displayed like this

![image](https://github.com/ash-project/spark/assets/96419810/d6b29a54-88fb-4a7a-b927-d8fc20a5bba2)

I though that maybe it should be displayed like this instead

![image](https://github.com/ash-project/spark/assets/96419810/b8ccd7bb-98d9-40bd-9158-a57d22999159)

