### PR TITLE
improvement: change `:wrap_list` doc to `x | list(x)`

### DIFF
--- a/lib/spark/types.ex
+++ b/lib/spark/types.ex
@@ -77,7 +77,7 @@ defmodule Spark.Types do
 
   def doc_type({:wrap_list, subtype}) do
     str = doc_type(subtype)
-    "list(#{str}) | #{str}"
+    "#{str} | list(#{str})"
   end
 
   def doc_type({:list_of, subtype}), do: doc_type({:list, subtype})


### PR DESCRIPTION
From comment in https://github.com/ash-project/ash/pull/700: changes order for `:wrap_list` doc from `list(x) | x` to `x | list(x)`.

No idea if it is a "fix" or "improvement", put it in improvement to be on a safer side. 