### PR TITLE
chore: Add failing test for beam files with `?` in them.

### DIFF
--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -1,4 +1,5 @@
 defmodule Spark.DslTest do
+  alias Spark.DslTest.DslWithPredicate
   use ExUnit.Case
 
   import Spark.CodeHelpers
@@ -408,5 +409,12 @@ defmodule Spark.DslTest do
                      end
                    end
     end
+  end
+
+  test "predicate options correctly compile" do
+    assert {_, _, filename} =
+             :code.get_object_code(:"Elixir.Spark.Test.Contact.Dsl.Awesome?.Options")
+
+    refute to_string(filename) =~ "?"
   end
 end

--- a/test/support/contact/contact.ex
+++ b/test/support/contact/contact.ex
@@ -167,8 +167,18 @@ defmodule Spark.Test.Contact do
       ]
     }
 
+    @awesome_status %Spark.Dsl.Section{
+      name: :awesome?,
+      schema: [
+        awesome?: [
+          type: :boolean,
+          required: true
+        ]
+      ]
+    }
+
     use Spark.Dsl.Extension,
-      sections: [@contact, @personal_details, @address, @presets],
+      sections: [@contact, @personal_details, @address, @presets, @awesome_status],
       verifiers: [Spark.Test.Contact.Verifiers.VerifyNotGandalf]
 
     def explain(dsl_state) do


### PR DESCRIPTION
Related to https://github.com/ash-project/reactor/issues/75 - compiling on Windows will fail if the filename contains a question mark.
