### PR TITLE
fix: Ensure `\\` for default argument values are rendered correctly in generated guides

### DIFF
--- a/lib/spark/cheat_sheet.ex
+++ b/lib/spark/cheat_sheet.ex
@@ -188,10 +188,10 @@ defmodule Spark.CheatSheet do
           to_string(key)
 
         {:optional, key} ->
-          "#{key} \\ nil"
+          "#{key} \\\\ nil"
 
         {:optional, key, default} ->
-          "#{key} \\ #{inspect(default)}"
+          "#{key} \\\\ #{inspect(default)}"
       end)
   end
 


### PR DESCRIPTION
As `\` is an escape character, to render a literal `\` you need two - so to render two, you need four

Noticed when browsing docs for AshAuthentication, eg. https://hexdocs.pm/ash_authentication/dsl-ashauthentication-strategy-password.html#authentication-strategies-password

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
