### PR TITLE
improvement: working `doc_type` for nested schemas

### DIFF
--- a/lib/spark/options_helpers.ex
+++ b/lib/spark/options_helpers.ex
@@ -74,8 +74,10 @@ defmodule Spark.OptionsHelpers do
           | {:fun, arity :: non_neg_integer}
           | {:in, [type] | Range.t()}
           | {:custom, module, function :: atom, args :: [any]}
-          | {:or, [type | {:keyword_list, schema} | {:non_empty_keyword_list, schema}]}
-          | {:list, type | {:keyword_list, schema} | {:non_empty_keyword_list, schema}}
+          | {:or,
+             [type | {:keyword_list, schema} | {:non_empty_keyword_list, schema} | {:map, schema}]}
+          | {:list,
+             type | {:keyword_list, schema} | {:non_empty_keyword_list, schema} | {:map, schema}}
           | {:tuple, [type]}
 
   @typedoc """


### PR DESCRIPTION
- Out of three types with support for nested keyed schemas (`keyword_list`, `non_empty_keyword_list` and `map`) only `keyword_list` had `doc_type` [case](https://github.com/ash-project/spark/blob/a843a3c202cc622085e141aaf3643ceccaa19152/lib/spark/types.ex#L22-L25) for nested schema. It was incorrect. So fixed that one and added support for other two.

- There was a case for `doc_type({:keyword_list, value_type})` (where `value_type` is a type, not a schema), but such type construct does not exist (at least it is not listed in typespecs). Removed it.

- Changed `Keyword.t` to simple `keyword` to match other type names.

- Offtop but there were three types of writing any: `any`, `"any"` and `any()`. Changed others to use the first variant.