### PR TITLE
fix: correct typespec/sanitisation for :in and :one_of

### DIFF
--- a/lib/spark/info_generator.ex
+++ b/lib/spark/info_generator.ex
@@ -316,8 +316,8 @@ defmodule Spark.InfoGenerator do
       {{:., [], [{:__aliases__, [], [:Range]}, :t]}, [],
        [spec_for_type(first, []), spec_for_type(last, [])]}
 
-  def spec_for_type({:in, types}, _opts) do
-    types
+  def spec_for_type({:in, values}, _opts) do
+    values
     |> Enum.map(&spec_for_type({:literal, &1}, []))
     |> case do
       [] ->
@@ -360,7 +360,7 @@ defmodule Spark.InfoGenerator do
   def spec_for_type(number, _opts) when is_number(number), do: number
   def spec_for_type(string, _opts) when is_binary(string), do: spec_for_type(:string, [])
 
-  def spec_for_type({:one_of, options}, opts), do: spec_for_type({:in, options}, opts)
+  def spec_for_type({:one_of, values}, opts), do: spec_for_type({:in, values}, opts)
 
   def spec_for_type({mod, arg}, _opts) when is_atom(mod) and is_list(arg),
     do: {{:module, [], Elixir}, {:list, [], Elixir}}

--- a/lib/spark/options_helpers.ex
+++ b/lib/spark/options_helpers.ex
@@ -30,7 +30,7 @@ defmodule Spark.OptionsHelpers do
   """
   @type type ::
           nimble_types
-          | {:one_of, [type]}
+          | {:one_of, [any]}
           | {:tagged_tuple, tag :: type, inner_type :: type}
           | {:spark_behaviour, module}
           | {:spark_behaviour, module, module}
@@ -72,7 +72,7 @@ defmodule Spark.OptionsHelpers do
           | :mfa
           | :mod_arg
           | {:fun, arity :: non_neg_integer}
-          | {:in, [type] | Range.t()}
+          | {:in, [any] | Range.t()}
           | {:custom, module, function :: atom, args :: [any]}
           | {:or,
              [type | {:keyword_list, schema} | {:non_empty_keyword_list, schema} | {:map, schema}]}
@@ -205,10 +205,10 @@ defmodule Spark.OptionsHelpers do
   defp sanitize_type(type, key) do
     case type do
       {:one_of, values} ->
-        {:in, sanitize_type(values, key)}
+        {:in, values}
 
       {:in, values} ->
-        {:in, sanitize_type(values, key)}
+        {:in, values}
 
       {:fun, args} when is_list(args) ->
         {:fun, Enum.count(args)}

--- a/lib/spark/types.ex
+++ b/lib/spark/types.ex
@@ -93,8 +93,8 @@ defmodule Spark.Types do
     "(#{args} -> #{doc_type(return)})"
   end
 
-  def doc_type({:one_of, choices}), do: doc_type({:in, choices})
-  def doc_type({:in, choices}), do: Enum.map_join(choices, " | ", &inspect/1)
+  def doc_type({:one_of, values}), do: doc_type({:in, values})
+  def doc_type({:in, values}), do: Enum.map_join(values, " | ", &inspect/1)
   def doc_type({:or, subtypes}), do: Enum.map_join(subtypes, " | ", &doc_type/1)
   def doc_type({:list, subtype}), do: "list(#{doc_type(subtype)})"
 


### PR DESCRIPTION
`:in` and `:one_of` work with a list of values, not a list of types. Corrected typespec and `sanitize_type` logic.

Also made naming of values list consistent - it had `values`, `types`, `choices`, `options`. Made all to use `values`.