### PR TITLE
Update Spark.Formatter to respect `extensions` list

### DIFF
--- a/lib/spark/formatter.ex
+++ b/lib/spark/formatter.ex
@@ -253,7 +253,7 @@ defmodule Spark.Formatter do
 
         if Keyword.has_key?(config, using) do
           type = config[using][:type] || using
-          {:ok, parse_extensions(opts, config, type), type, using}
+          {:ok, parse_extensions(opts, config[using], type), type, using}
         end
 
       _ ->


### PR DESCRIPTION
`Spark.Formatter`'s `parse_extensions` extension function expects the config for a specific module but loads the top level config. 


At the moment, it attempts to load the extensions from the top-level config:

  ```elixir
  config :spark, :formatter,
    remove_parens?: true,
    "Ash.Resource": [
      section_order: [
        :resource,
        :postgres,
        :attributes,
        :relationships,
        :aggregates,
        :calculations
      ]
    ],
    "MyApp.Resource": [
      # Use this if you use a module that is not the spark DSL itself.
      # For example, you might have a "base" that you use instead that sets some simple defaults.

      # This tells us what the actual thing is so we know what extensions are included automatically.
      type: Ash.Resource,

      # Tell us what extensions might be added under the hood
      extensions: [MyApp.ResourceExtension],
      section_order: [...]
    ]
  ```

It should instead load the extensions from the module we are formatting eg:

```elixir
[
  # Use this if you use a module that is not the spark DSL itself.
  # For example, you might have a "base" that you use instead that sets some simple defaults.

  # This tells us what the actual thing is so we know what extensions are included automatically.
  type: Ash.Resource,

  # Tell us what extensions might be added under the hood
  extensions: [MyApp.ResourceExtension],
  section_order: [...]
]
```

# Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
