### PR TITLE
Use term_to_iovec instead of term_to_binary

### DIFF
--- a/lib/spark/code_helpers.ex
+++ b/lib/spark/code_helpers.ex
@@ -11,7 +11,7 @@ defmodule Spark.CodeHelpers do
   def code_identifier(code) do
     code
     |> strip_meta()
-    |> :erlang.term_to_binary()
+    |> :erlang.term_to_iovec()
     |> :erlang.md5()
     |> Base.encode16()
   end


### PR DESCRIPTION
md5 accepts iodata, so it is more performant to use term_to_iovec. Just a micro optimization

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
