### PR TITLE
fix: ensure atom before check compiled

### DIFF
--- a/lib/spark/formatter.ex
+++ b/lib/spark/formatter.ex
@@ -281,7 +281,7 @@ defmodule Spark.Formatter do
       end
       |> List.wrap()
       |> Enum.flat_map(fn extension ->
-        case Code.ensure_compiled(extension) do
+        case is_atom(extension) and Code.ensure_compiled(extension) do
           {:module, module} ->
             if Spark.implements_behaviour?(module, Spark.Dsl.Extension) do
               [module]


### PR DESCRIPTION
We have something like

```elixir
defmodule MyApp.Post do
  use MyApp.Resource, comment: "blah blah"
end
```

and the `"blah blah"` is passed as an extension to spark formatter.
so before calling `Code.ensure_compiled/1`, 
`is_atom/1` or any other type validation should be performed, I think.