### PR TITLE
add :impl option type

### DIFF
--- a/lib/spark/options/docs.ex
+++ b/lib/spark/options/docs.ex
@@ -160,6 +160,9 @@ defmodule Spark.Options.Docs do
   defp get_raw_type_str({:protocol, module}),
     do: "value that implements the `#{inspect(module)}` protocol"
 
+  defp get_raw_type_str({:impl, module}),
+    do: "module for which the `#{inspect(module)}` protocol is implemented"
+
   defp get_raw_type_str({:struct, struct_type}), do: "struct of type `#{inspect(struct_type)}`"
   defp get_raw_type_str(:struct), do: "struct"
   defp get_raw_type_str({:spark, module}), do: "`#{inspect(module)}`"
@@ -199,6 +202,7 @@ defmodule Spark.Options.Docs do
 
   def dsl_docs_type({:behaviour, _mod}), do: "module"
   def dsl_docs_type({:protocol, protocol}), do: "an `#{inspect(protocol)}` value"
+  def dsl_docs_type({:impl, protocol}), do: "a module implementing `#{inspect(protocol)}`"
   def dsl_docs_type({:spark, mod}), do: dsl_docs_type({:behaviour, mod})
   def dsl_docs_type({:spark_behaviour, mod}), do: dsl_docs_type({:behaviour, mod})
 
@@ -460,7 +464,7 @@ defmodule Spark.Options.Docs do
       {:tagged_tuple, tag, subtype} ->
         quote do: {unquote(tag), unquote(type_to_spec(subtype))}
 
-      {tag, _} when tag in [:behaviour, :spark_behaviour, :protocol, :spark] ->
+      {tag, _} when tag in [:behaviour, :spark_behaviour, :protocol, :spark, :impl] ->
         quote(do: module())
 
       {:spark_function_behaviour, _, _} ->

--- a/test/options/impl_validator_test.exs
+++ b/test/options/impl_validator_test.exs
@@ -1,0 +1,62 @@
+defmodule Spark.Options.ImplValidatorTest do
+  use ExUnit.Case
+  require Spark.Options.Validator
+
+  defmodule MySchema do
+    @schema [
+      foo: [
+        type: {:impl, Enumerable}
+      ],
+      bar: [
+        type: {:impl, Integer}
+      ],
+      baz: [
+        type: {:impl, ThisDoesNotReallyExist}
+      ]
+    ]
+
+    use Spark.Options.Validator, schema: @schema, define_deprecated_access?: true
+  end
+
+  describe "impl option" do
+    test "accepts a module for which a protocol is implemented" do
+      MySchema.validate!(foo: List)
+    end
+
+    test "rejects a module for which a protocol is not implemented" do
+      assert_raise(
+        Spark.Options.ValidationError,
+        "protocol Enumerable is not implemented by Enum",
+        fn ->
+          MySchema.validate!(foo: Enum)
+        end
+      )
+    end
+
+    test "rejects module that is not a protocol" do
+      assert_raise(Spark.Options.ValidationError, "Integer is not a protocol", fn ->
+        MySchema.validate!(bar: Enum)
+      end)
+    end
+
+    test "rejects module that does not exist" do
+      assert_raise(
+        Spark.Options.ValidationError,
+        "protocol Enumerable is not implemented by ThisDoesNotReallyExist",
+        fn ->
+          MySchema.validate!(foo: ThisDoesNotReallyExist)
+        end
+      )
+    end
+
+    test "rejects protocol name that is not a protocol" do
+      assert_raise(
+        Spark.Options.ValidationError,
+        "ThisDoesNotReallyExist is not a protocol",
+        fn ->
+          MySchema.validate!(baz: Enum)
+        end
+      )
+    end
+  end
+end


### PR DESCRIPTION
`:impl` option type is similar to `:protocol`, but accepts module name instead of concrete value.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
