### PR TITLE
disable introspection section in cheatsheets if target module is not documented

### DIFF
--- a/lib/mix/tasks/spark.cheat_sheets.ex
+++ b/lib/mix/tasks/spark.cheat_sheets.ex
@@ -8,13 +8,7 @@ defmodule Mix.Tasks.Spark.CheatSheets do
 
     {opts, _} =
       OptionParser.parse!(opts,
-        switches: [
-          strip_prefix: :string,
-          check: :boolean,
-          extensions: :string,
-          check: :string,
-          no_introspection: :boolean
-        ]
+        switches: [strip_prefix: :string, check: :boolean, extensions: :string, check: :string]
       )
 
     extensions =
@@ -26,16 +20,12 @@ defmodule Mix.Tasks.Spark.CheatSheets do
       |> Enum.map(&Module.concat([&1]))
       |> Enum.uniq()
 
-    cheatsheet_opts = [
-      no_introspection: Keyword.get(opts, :no_introspection, false)
-    ]
-
     if !opts[:check] do
       File.rm_rf!("documentation/dsls")
     end
 
     for extension <- extensions do
-      cheat_sheet = Spark.CheatSheet.cheat_sheet(extension, cheatsheet_opts)
+      cheat_sheet = Spark.CheatSheet.cheat_sheet(extension)
       File.mkdir_p!("documentation/dsls")
       extension_name = Spark.Mix.Helpers.extension_name(extension, opts)
 

--- a/lib/mix/tasks/spark.cheat_sheets.ex
+++ b/lib/mix/tasks/spark.cheat_sheets.ex
@@ -8,7 +8,13 @@ defmodule Mix.Tasks.Spark.CheatSheets do
 
     {opts, _} =
       OptionParser.parse!(opts,
-        switches: [strip_prefix: :string, check: :boolean, extensions: :string, check: :string]
+        switches: [
+          strip_prefix: :string,
+          check: :boolean,
+          extensions: :string,
+          check: :string,
+          no_introspection: :boolean
+        ]
       )
 
     extensions =
@@ -20,12 +26,16 @@ defmodule Mix.Tasks.Spark.CheatSheets do
       |> Enum.map(&Module.concat([&1]))
       |> Enum.uniq()
 
+    cheatsheet_opts = [
+      no_introspection: Keyword.get(opts, :no_introspection, false)
+    ]
+
     if !opts[:check] do
       File.rm_rf!("documentation/dsls")
     end
 
     for extension <- extensions do
-      cheat_sheet = Spark.CheatSheet.cheat_sheet(extension)
+      cheat_sheet = Spark.CheatSheet.cheat_sheet(extension, cheatsheet_opts)
       File.mkdir_p!("documentation/dsls")
       extension_name = Spark.Mix.Helpers.extension_name(extension, opts)
 

--- a/lib/spark/cheat_sheet.ex
+++ b/lib/spark/cheat_sheet.ex
@@ -4,7 +4,7 @@ defmodule Spark.CheatSheet do
   @doc """
   Generate a cheat sheet for a given DSL
   """
-  def cheat_sheet(extension, opts \\ []) do
+  def cheat_sheet(extension) do
     patches =
       Enum.map_join(
         extension.dsl_patches(),
@@ -13,13 +13,13 @@ defmodule Spark.CheatSheet do
              section_path: section_path,
              entity: entity
            } ->
-          entity_cheat_sheet(entity, section_path, opts)
+          entity_cheat_sheet(entity, section_path)
         end
       )
 
     body =
       extension.sections()
-      |> Enum.map_join("\n\n", &section_cheat_sheet(&1, [], opts))
+      |> Enum.map_join("\n\n", &section_cheat_sheet(&1))
       |> Kernel.<>("\n")
       |> Kernel.<>(patches)
 
@@ -37,7 +37,7 @@ defmodule Spark.CheatSheet do
     """
   end
 
-  def section_cheat_sheet(section, path, opts) do
+  def section_cheat_sheet(section, path \\ []) do
     examples =
       case section.examples do
         [] ->
@@ -74,8 +74,8 @@ defmodule Spark.CheatSheet do
 
       #{options_table(options, path ++ [section.name])}
 
-      #{Enum.map_join(section.sections, &section_cheat_sheet(&1, path ++ [section.name], opts))}
-      #{Enum.map_join(section.entities, &entity_cheat_sheet(&1, path ++ [section.name], opts))}
+      #{Enum.map_join(section.sections, &section_cheat_sheet(&1, path ++ [section.name]))}
+      #{Enum.map_join(section.entities, &entity_cheat_sheet(&1, path ++ [section.name]))}
       """
     else
       """
@@ -86,20 +86,20 @@ defmodule Spark.CheatSheet do
 
       #{examples}
 
-      #{Enum.map_join(section.sections, &section_cheat_sheet(&1, path ++ [section.name], opts))}
-      #{Enum.map_join(section.entities, &entity_cheat_sheet(&1, path ++ [section.name], opts))}
+      #{Enum.map_join(section.sections, &section_cheat_sheet(&1, path ++ [section.name]))}
+      #{Enum.map_join(section.entities, &entity_cheat_sheet(&1, path ++ [section.name]))}
       """
     end
   end
 
-  defp entity_cheat_sheet(entity, path, opts) do
+  defp entity_cheat_sheet(entity, path) do
     nested_entities =
       entity.entities
       |> List.wrap()
       |> Enum.flat_map(&elem(&1, 1))
 
     nested_entity_docs =
-      Enum.map_join(nested_entities, &entity_cheat_sheet(&1, path ++ [entity.name], opts))
+      Enum.map_join(nested_entities, &entity_cheat_sheet(&1, path ++ [entity.name]))
 
     options =
       entity.schema
@@ -165,7 +165,7 @@ defmodule Spark.CheatSheet do
 
     #{reference}
 
-    #{entity_properties(entity, opts)}
+    #{entity_properties(entity)}
     """
   end
 
@@ -221,16 +221,12 @@ defmodule Spark.CheatSheet do
     end)
   end
 
-  defp entity_properties(entity, opts) do
-    if Keyword.get(opts, :no_introspection, false) do
-      ""
-    else
-      """
-      ### Introspection
+  defp entity_properties(entity) do
+    """
+    ### Introspection
 
-      Target: `#{inspect(entity.target)}`
-      """
-    end
+    Target: `#{inspect(entity.target)}`
+    """
   end
 
   defp options_table(options, path, positional_args \\ [])

--- a/lib/spark/cheat_sheet.ex
+++ b/lib/spark/cheat_sheet.ex
@@ -222,11 +222,21 @@ defmodule Spark.CheatSheet do
   end
 
   defp entity_properties(entity) do
-    """
-    ### Introspection
+    docs =
+      case Code.fetch_docs(entity.target) do
+        {:docs_v1, _, _, _, docs, _, _} -> docs
+        {:error, _} -> :hidden
+      end
 
-    Target: `#{inspect(entity.target)}`
-    """
+    if docs == :hidden do
+      ""
+    else
+      """
+      ### Introspection
+
+      Target: `#{inspect(entity.target)}`
+      """
+    end
   end
 
   defp options_table(options, path, positional_args \\ [])


### PR DESCRIPTION
In many cases when the target is just a simple struct and there is really nothing to document. But `@moduledoc false` causes warnings about referencing hidden modules. `--no-introspection` option  instructs `mix spark.cheat_sheets`  to skip generation of Introspection sections

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
