### PR TITLE
discussion(Mixed Lists): added some unit tests to show the use-case

### DIFF
--- a/test/options/mixed_list_test.exs
+++ b/test/options/mixed_list_test.exs
@@ -1,0 +1,79 @@
+defmodule Spark.Options.MixedListTypeTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  require Spark.Options.Validator
+
+  defmodule MyMixedListSchema do
+    @foo_opts [
+      enabled?: [type: :boolean, required?: true]
+    ]
+    @bar_opts [
+      enabled?: [type: :boolean, required?: false]
+    ]
+    @baz_opts [
+      enabled?: [type: :boolean, required?: false]
+    ]
+
+    @allowed_keys [:foo, :bar, :baz]
+
+    @optional_key_opts [
+      foo: {:non_empty_keyword_list, @foo_opts},
+      bar: {:non_empty_keyword_list, @bar_opts},
+      baz: {:non_empty_keyword_list, @baz_opts},
+    ]
+
+    @list_type {:in, @allowed_keys ++ @optional_key_opts}
+
+    @schema [
+      schema: [
+        type: {:list, @list_type},
+      ]
+    ]
+
+    use Spark.Options.Validator, schema: @schema
+  end
+
+  describe "mixed list types" do
+    test "can use only atoms" do
+      MyMixedListSchema.validate!(schema: [:foo])
+      MyMixedListSchema.validate!(schema: [:foo, :bar])
+      MyMixedListSchema.validate!(schema: [:foo, :bar, :baz])
+    end
+
+    test "can use only keywords" do
+      MyMixedListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+        ]
+      )
+      MyMixedListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [enabled?: false],
+        ]
+      )
+      MyMixedListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [enabled?: false],
+          baz: [enabled?: false],
+        ]
+      )
+      MyMixedListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [],
+          baz: [enabled?: false],
+        ]
+      )
+    end
+
+    test "can mix atoms and keywords" do
+      MyMixedListSchema.validate!(schema: [:foo, bar: [enabled?: true]])
+      MyMixedListSchema.validate!(schema: [:foo, bar: [enabled?: true], baz: [enabled?: true]])
+      MyMixedListSchema.validate!(schema: [:foo, [bar: [enabled?: true]], :baz])
+    end
+  end
+end

--- a/test/options/mixed_wrap_list_test.exs
+++ b/test/options/mixed_wrap_list_test.exs
@@ -1,0 +1,79 @@
+defmodule Spark.Options.MixedWrapListTypeTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  require Spark.Options.Validator
+
+  defmodule MyMixedWrapListSchema do
+    @foo_opts [
+      enabled?: [type: :boolean, required?: true]
+    ]
+    @bar_opts [
+      enabled?: [type: :boolean, required?: false]
+    ]
+    @baz_opts [
+      enabled?: [type: :boolean, required?: false]
+    ]
+
+    @allowed_keys [:foo, :bar, :baz]
+
+    @optional_key_opts [
+      foo: {:non_empty_keyword_list, @foo_opts},
+      bar: {:non_empty_keyword_list, @bar_opts},
+      baz: {:non_empty_keyword_list, @baz_opts},
+    ]
+
+    @list_type {:in, @allowed_keys ++ @optional_key_opts}
+
+    @schema [
+      schema: [
+        type: {:wrap_list, @list_type},
+      ]
+    ]
+
+    use Spark.Options.Validator, schema: @schema
+  end
+
+  describe "mixed wrap_list types" do
+    test "can use only atoms" do
+      MyMixedWrapListSchema.validate!(schema: :foo)
+      MyMixedWrapListSchema.validate!(schema: [:foo, :bar])
+      MyMixedWrapListSchema.validate!(schema: [:foo, :bar, :baz])
+    end
+
+    test "can use only keywords" do
+      MyMixedWrapListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+        ]
+      )
+      MyMixedWrapListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [enabled?: false],
+        ]
+      )
+      MyMixedWrapListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [enabled?: false],
+          baz: [enabled?: false],
+        ]
+      )
+      MyMixedWrapListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [],
+          baz: [enabled?: false],
+        ]
+      )
+    end
+
+    test "can mix atoms and keywords" do
+      MyMixedWrapListSchema.validate!(schema: [:foo, bar: [enabled?: true]])
+      MyMixedWrapListSchema.validate!(schema: [:foo, bar: [enabled?: true], baz: [enabled?: true]])
+      MyMixedWrapListSchema.validate!(schema: [:foo, [bar: [enabled?: true]], :baz])
+    end
+  end
+end

--- a/test/options/simple_mixed_atom_tuple_list_test.exs
+++ b/test/options/simple_mixed_atom_tuple_list_test.exs
@@ -1,0 +1,48 @@
+defmodule Spark.Options.SimpleMixedAtomTupleListTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  require Spark.Options.Validator
+
+  defmodule MySimpleMixedAtomTupleListSchema do
+    @list_type {:in, [:atom, {:tuple, :keyword_list}]}
+
+    @schema [
+      schema: [
+        type: {:wrap_list, @list_type},
+      ]
+    ]
+
+    use Spark.Options.Validator, schema: @schema
+  end
+
+  describe "mixed wrap_list types" do
+    test "can use only atoms" do
+      MySimpleMixedAtomTupleListSchema.validate!(schema: :foo)
+      MySimpleMixedAtomTupleListSchema.validate!(schema: [:foo, :bar])
+      MySimpleMixedAtomTupleListSchema.validate!(schema: [:foo, :bar, :baz])
+    end
+
+    test "can use only keywords" do
+      MySimpleMixedAtomTupleListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+        ]
+      )
+      MySimpleMixedAtomTupleListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [enabled?: false],
+        ]
+      )
+      MySimpleMixedAtomTupleListSchema.validate!(
+        schema: [
+          foo: [enabled?: true],
+          bar: [enabled?: false],
+          baz: [enabled?: false],
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is a starting point of a discussion. Just added some unit tests to display the intent, as per the discussions over on the Discord's Spark channel.

So the use-case is basically being able to be able to write a Spark Entity's type as the following:
```elixir
  my_dsl do
    my_thing :one, :two, :three, four: "four", five: "five
    # ... or
    my_thing [:one, :two, :three, four: "four", five: "five]
  end
```

This is the same way you could do `defstruct :one, :two, three: "three"` to provide default values for some struct fields.

Instead of the defstruct behaviour though, the idea is that the keys that does have a default declared for them in a `:keyword_list` would just default to their values, and so the final data would be a valid Keyword list.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
