### PR TITLE
doc: Use full module name (`Spark.Dsl.Transformer`) in `eval/3` doc

### DIFF
--- a/lib/spark/dsl/transformer.ex
+++ b/lib/spark/dsl/transformer.ex
@@ -76,7 +76,7 @@ defmodule Spark.Dsl.Transformer do
   fields = the_primary_key_fields
 
   dsl_state =
-    Transformer.eval(
+    Spark.Dsl.Transformer.eval(
       dsl_state,
       [fields: fields],
       quote do


### PR DESCRIPTION
Not sure if it's bug, feel free to close.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
