### PR TITLE
Fix missing find and replace

### DIFF
--- a/documentation/tutorials/get-started-with-spark.md
+++ b/documentation/tutorials/get-started-with-spark.md
@@ -36,7 +36,7 @@ defmodule MyApp.PersonValidator do
     end
 
     # This syntax is also supported
-    # field :email, :string, check: &String.contains?(&1, "@"), process: &String.trim/1
+    # field :email, :string, check: &String.contains?(&1, "@"), transform: &String.trim/1
   end
 end
 


### PR DESCRIPTION
# Contributor checklist

Completed the `process` -> `transform` find and replace by fixing missed instances.

However, I'm now wondering if retaining the original `process` name might have been better to clearly distinguish it from the `transform` callback function within the `Transformer` module.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
