### PR TITLE
fix: add `get_raw_type/1` clause for `:number` type

### DIFF
--- a/lib/spark/options/docs.ex
+++ b/lib/spark/options/docs.ex
@@ -247,6 +247,7 @@ defmodule Spark.Options.Docs do
   def dsl_docs_type(:non_neg_integer), do: "non_neg_integer"
   def dsl_docs_type(:pos_integer), do: "pos_integer"
   def dsl_docs_type(:float), do: "float"
+  def dsl_docs_type(:number), do: "number"
   def dsl_docs_type(:timeout), do: "timeout"
   def dsl_docs_type(:pid), do: "pid"
   def dsl_docs_type(:mfa), do: "mfa"

--- a/lib/spark/options/docs.ex
+++ b/lib/spark/options/docs.ex
@@ -129,6 +129,7 @@ defmodule Spark.Options.Docs do
   defp get_raw_type_str(:non_neg_integer), do: "`t:non_neg_integer/0`"
   defp get_raw_type_str(:pos_integer), do: "`t:pos_integer/0`"
   defp get_raw_type_str(:float), do: "`t:float/0`"
+  defp get_raw_type_str(:number), do: "`t:number/0`"
   defp get_raw_type_str(:string), do: "`t:String.t/0`"
   defp get_raw_type_str(:keyword_list), do: "`t:keyword/0`"
   defp get_raw_type_str(:non_empty_keyword_list), do: "non-empty `t:keyword/0`"


### PR DESCRIPTION
fixes regressions after the `:number` type implementation

i apologize for this fxck up from my side. i forgot to double check _everything_ compiles by using local Spark as a dep

fixes regression made in #183 of not compiling possibly in all cases. please retire version [v2.2.61](https://github.com/ash-project/spark/tree/v2.2.61)

i'm sorry, i will be much more accurate and do thorough testing before opening a PR

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
