### PR TITLE
Record Source Annotations

### DIFF
--- a/documentation/how_to/use-source-annotations.md
+++ b/documentation/how_to/use-source-annotations.md
@@ -85,29 +85,40 @@ end)
 first_entity_anno = Spark.Dsl.Extension.get_entity_anno(dsl_state, [:my_section], 0)
 ```
 
-### Entity Anno Fields (Optional)
+### Entity Annotations
 
-For convenience, entities can also include annotations directly in their structs
-by defining an `anno_field`:
+For direct access to annotations, entities should include the
+`__spark_metadata__` field in their struct definition:
 
 ```elixir
-# Define entity with anno_field
+defmodule MyEntity do
+  defstruct [
+    :name,
+    :__spark_metadata__ # Required for annotation access
+  ]
+end
+
 @my_entity %Spark.Dsl.Entity{
   name: :my_entity,
   target: MyEntity,
-  anno_field: :anno, # Automatically populated with location info
   schema: [
     name: [type: :atom, required: true]
   ]
 }
 
-# Access annotation from entity struct
+# Access annotations
 entities = Spark.Dsl.Extension.get_entities(dsl_state, [:my_section])
 Enum.each(entities, fn entity ->
-  if entity.anno do
-    line = :erl_anno.location(entity.anno)
-    file = :erl_anno.file(entity.anno) |> to_string()
-    IO.puts("Entity #{entity.name} defined at #{file}:#{line}")
+  if entity_anno = Spark.Dsl.Entity.anno(entity) do
+    line = :erl_anno.location(entity_anno)
+    file = :erl_anno.file(entity_anno) |> to_string()
+    IO.puts("Entity defined at #{file}:#{line}")
+  end
+
+  if name_anno = Spark.Dsl.Entity.property_anno(entity, :name) do
+    line = :erl_anno.location(name_anno)
+    file = :erl_anno.file(name_anno) |> to_string()
+    IO.puts("Entity name property defined at #{file}:#{line}")
   end
 end)
 ```

--- a/documentation/how_to/use-source-annotations.md
+++ b/documentation/how_to/use-source-annotations.md
@@ -1,0 +1,347 @@
+# Using Source Annotations
+
+Spark automatically tracks source location information for all DSL elements
+using Erlang's `:erl_anno` module. This provides comprehensive location tracking
+for sections, options, and entities, enabling better error messages, IDE
+integration, and debugging capabilities.
+
+## What are Source Annotations?
+
+Source annotations capture metadata about where DSL elements are defined in your
+source code, including:
+
+- **File path**: The source file where the DSL element is declared
+- **Line number**: The exact line where the element starts
+- **End location**: The line where DSL blocks end (available on OTP 28+,
+  requires Elixir Parser Configuration)
+
+```elixir
+defmodule Acme.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :acme,
+      elixirc_options: [
+        parser_options: [
+          token_metadata: true,
+          parser_columns: true
+        ]
+      ],
+      # ...
+    ]
+  end
+end
+```
+
+Spark tracks annotations for:
+- **Sections**: Location where section blocks are defined (`section do ... end`)
+- **Options**: Location where individual options are set (`option_name "value"`)
+- **Entities**: Location where entities are declared (`entity :name do ... end`)
+
+## Annotation Introspection
+
+### Universal Access via Introspection Functions
+
+Spark provides introspection functions that work regardless of whether entities
+define an `anno_field`. These functions access annotation data stored in the DSL
+state:
+
+```elixir
+# Get DSL state
+dsl_state = MyModule.spark_dsl_config()
+
+# Section annotations
+section_anno = Spark.Dsl.Extension.get_section_anno(dsl_state, [:my_section])
+if section_anno do
+  # Extract line number (Spark currently provides line numbers only)
+  line = case :erl_anno.location(section_anno) do
+    {line_num, _col} -> line_num
+    line_num -> line_num
+  end
+  file = :erl_anno.file(section_anno) |> to_string()
+  IO.puts("Section defined at #{file}:#{line}")
+end
+
+# Option annotations
+option_anno = Spark.Dsl.Extension.get_opt_anno(dsl_state, [:my_section], :option_name)
+if option_anno do
+  line = :erl_anno.location(option_anno)
+  file = :erl_anno.file(option_anno) |> to_string()
+  IO.puts("Option defined at #{file}:#{line}")
+end
+
+# Entity annotations (all entities)
+entities_anno = Spark.Dsl.Extension.get_entities_anno(dsl_state, [:my_section])
+Enum.each(entities_anno, fn anno ->
+  if anno do
+    line = :erl_anno.location(anno)
+    file = :erl_anno.file(anno) |> to_string()
+    IO.puts("Entity defined at #{file}:#{line}")
+  end
+end)
+
+# Entity annotation (specific entity by index)
+first_entity_anno = Spark.Dsl.Extension.get_entity_anno(dsl_state, [:my_section], 0)
+```
+
+### Entity Anno Fields (Optional)
+
+For convenience, entities can also include annotations directly in their structs
+by defining an `anno_field`:
+
+```elixir
+# Define entity with anno_field
+@my_entity %Spark.Dsl.Entity{
+  name: :my_entity,
+  target: MyEntity,
+  anno_field: :anno, # Automatically populated with location info
+  schema: [
+    name: [type: :atom, required: true]
+  ]
+}
+
+# Access annotation from entity struct
+entities = Spark.Dsl.Extension.get_entities(dsl_state, [:my_section])
+Enum.each(entities, fn entity ->
+  if entity.anno do
+    line = :erl_anno.location(entity.anno)
+    file = :erl_anno.file(entity.anno) |> to_string()
+    IO.puts("Entity #{entity.name} defined at #{file}:#{line}")
+  end
+end)
+```
+
+## Working with Annotations
+
+Annotations use Erlang's `:erl_anno` module, which provides several utilities:
+
+```elixir
+# Check if something is an annotation
+:erl_anno.is_anno(anno)
+
+# Get the location (line number or {line, column})
+# Note: Spark currently only provides line numbers, not column information
+location = :erl_anno.location(anno)
+
+# Helper function to extract line number from location
+get_line = fn location ->
+  case location do
+    {line_num, _column} -> line_num  # Future column support
+    line_num when is_integer(line_num) -> line_num  # Current Spark behavior
+  end
+end
+
+line = get_line.(location)
+
+# Get the file (returns :undefined or a charlist)
+file = :erl_anno.file(anno)
+
+# Convert charlist to string safely
+file_string = case file do
+  :undefined -> "unknown"
+  charlist -> to_string(charlist)
+end
+
+# Get the end location (OTP 28+, returns :undefined if not available)
+if function_exported?(:erl_anno, :end_location, 1) do
+  end_location = :erl_anno.end_location(anno)
+end
+```
+
+## Use Cases
+
+### Enhanced Error Messages in Verifiers
+
+Create precise error messages that point to the exact source location:
+
+```elixir
+defmodule MyLibrary.Verifiers.UniqueNames do
+  use Spark.Dsl.Verifier
+
+  def verify(dsl_state) do
+    entities = Spark.Dsl.Extension.get_entities(dsl_state, [:my_section])
+    entities_anno = Spark.Dsl.Transformer.get_entities_anno(dsl_state, [:my_section])
+
+    case find_duplicate(entities) do
+      nil -> :ok
+      {duplicate_name, index} ->
+        location = Enum.at(entities_anno, index)
+
+        {:error,
+         Spark.Error.DslError.exception(
+           message: "Duplicate entity name: #{duplicate_name}",
+           path: [:my_section, duplicate_name],
+           module: Spark.Dsl.Verifier.get_persisted(dsl_state, :module),
+           location: location
+         )}
+    end
+  end
+end
+```
+
+### Enhanced Error Messages in Transformers
+
+```elixir
+defmodule MyLibrary.Transformers.ValidateEntity do
+  use Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    entities = Spark.Dsl.Extension.get_entities(dsl_state, [:my_section])
+    entities_anno = Spark.Dsl.Transformer.get_entities_anno(dsl_state, [:my_section])
+
+    entities
+    |> Enum.with_index()
+    |> Enum.each(fn {entity, index} ->
+      if invalid?(entity) do
+        location = Enum.at(entities_anno, index)
+
+        raise Spark.Error.DslError,
+          message: "Invalid configuration for #{entity.name}",
+          path: [:my_section, entity.name],
+          location: location
+      end
+    end)
+
+    {:ok, dsl_state}
+  end
+end
+```
+
+### IDE Integration and Language Servers
+
+Language servers can provide enhanced features using annotation data:
+
+```elixir
+defmodule MyLanguageServer do
+  def find_definition(file, line, column) do
+    # Find modules that might contain DSL at this location
+    modules = find_modules_in_file(file)
+
+    Enum.find_value(modules, fn module ->
+      dsl_state = module.spark_dsl_config()
+
+      # Check section annotations
+      Enum.find_value(dsl_state, fn {path, config} ->
+        if match_location?(config.section_anno, line) do
+          {:section, path, config.section_anno}
+        end
+      end) ||
+
+      # Check entity annotations
+      find_entity_at_location(dsl_state, line)
+    end)
+  end
+end
+```
+
+### Debugging and Development Tools
+
+Create debugging utilities that show DSL source locations:
+
+```elixir
+defmodule MyLibrary.Debug do
+  def inspect_dsl_sources(module) do
+    dsl_state = module.spark_dsl_config()
+
+    # Show all DSL elements with their locations
+    Enum.each(dsl_state, fn {path, config} ->
+      IO.puts("Section #{inspect(path)}:")
+
+      if config.section_anno do
+        print_location("  Section", config.section_anno)
+      end
+
+      # Show options
+      config.opts_anno
+      |> Enum.each(fn {opt_name, anno} ->
+        print_location("  Option #{opt_name}", anno)
+      end)
+
+      # Show entities
+      config.entities_anno
+      |> Enum.with_index()
+      |> Enum.each(fn {anno, index} ->
+        entity = Enum.at(config.entities, index)
+        entity_name = if entity, do: entity.name || index, else: index
+        print_location("  Entity #{entity_name}", anno)
+      end)
+    end)
+  end
+
+  defp print_location(label, anno)
+  defp print_location(label, nil), do: nil
+  defp print_location(label, anno) do
+    line = :erl_anno.location(anno)
+    file = :erl_anno.file(anno) |> to_string() |> Path.relative_to_cwd()
+    IO.puts("    #{label}: #{file}:#{line}")
+  end
+end
+```
+
+## Best Practices
+
+### 1. Always Include Location in DslErrors
+
+When creating DslErrors, include location information whenever available:
+
+```elixir
+# Get the appropriate annotation for your error context
+location = case error_type do
+  :section_error ->
+    Spark.Dsl.Transformer.get_section_anno(dsl_state, path)
+  :option_error ->
+    Spark.Dsl.Transformer.get_opt_anno(dsl_state, path, option_name)
+  :entity_error ->
+    Spark.Dsl.Transformer.get_entity_anno(dsl_state, path, entity_index)
+end
+
+{:error,
+ Spark.Error.DslError.exception(
+   message: "Clear error description",
+   path: path,
+   module: module,
+   location: location
+ )}
+```
+
+### 2. Handle Missing Annotations Gracefully
+
+Not all annotations may be available (e.g., programmatically generated DSL
+elements):
+
+```elixir
+location_info = if anno do
+  line = :erl_anno.location(anno)
+  file = :erl_anno.file(anno) |> to_string()
+  " at #{file}:#{line}"
+else
+  ""
+end
+
+IO.puts("Error in entity#{location_info}")
+```
+
+### 3. Use Both Introspection and Anno Fields
+
+- **Use introspection functions** for universal access in verifiers and
+  transformers
+- **Use anno fields** in entity structs for convenient access in application
+  code
+
+### 4. Check OTP Version for End Location
+
+End location tracking requires OTP 28+:
+
+```elixir
+if function_exported?(:erl_anno, :end_location, 1) do
+  end_location = :erl_anno.end_location(anno)
+  # Use end location for precise span information
+end
+```
+
+## Current Limitations
+
+- Column information is not currently tracked (only line numbers)
+- End Location is only tracked for OTP28+
+- End Location is not available for multiline options

--- a/documentation/how_to/writing-extensions.md
+++ b/documentation/how_to/writing-extensions.md
@@ -13,3 +13,7 @@ Extension writing gets a bit more complicated when you get into the world of tra
 ## Introspection
 
 Use functions in `Spark.Dsl.Extension` to retrieve the stored values from the DSL and expose them in a module. The convention is to place functions for something like `MyApp.MyExtension` in `MyApp.MyExtension.Info`. Using introspection functions like this allows for a richer introspection API (i.e not just getting and retrieving raw values), and it also allows us to add type specs and documentation, which is helpful when working generically. I.e `module_as_variable.table()` can't be known by dialyzer, whereas `Extension.table(module)` can be.
+
+## Source Annotations
+
+Spark automatically tracks source location information for all DSL elements. This enables better error messages, IDE integration, and debugging capabilities. See [Using Source Annotations](use-source-annotations.md) for details on accessing and using this information in your extensions.

--- a/documentation/tutorials/get-started-with-spark.md
+++ b/documentation/tutorials/get-started-with-spark.md
@@ -60,7 +60,9 @@ uses under the hood to allow users to write in the DSL syntax described above.
 ```elixir
 defmodule MyLibrary.Validator.Dsl do
   defmodule Field do
-    defstruct [:name, :type, :transform, :check]
+    # The __spark_metadata__ field is required for Spark entities
+    # It stores source location information for better error messages and tooling
+    defstruct [:name, :type, :transform, :check, :__spark_metadata__]
   end
 
   @field %Spark.Dsl.Entity{

--- a/lib/mix/tasks/spark.cheat_sheets_in_search.ex
+++ b/lib/mix/tasks/spark.cheat_sheets_in_search.ex
@@ -5,14 +5,17 @@ if Code.ensure_loaded?(Jason) do
     use Mix.Task
 
     def run(opts) do
-      IO.warn("""
-      You should switch to using `Spark.Docs.search_data_for(dsl_module)` instead of this task.
+      Spark.Warning.warn_deprecated(
+        "mix spark.cheat_sheets_in_search task",
+        """
+        You should switch to using `Spark.Docs.search_data_for(dsl_module)` instead of this task.
 
-      i.e
+        i.e
 
-        {"documentation/dsls/DSL-Ash.Resource.md",
-         search_data: Spark.Docs.search_data_for(Ash.Resource.Dsl)},
-      """)
+          {"documentation/dsls/DSL-Ash.Resource.md",
+           search_data: Spark.Docs.search_data_for(Ash.Resource.Dsl)},
+        """
+      )
 
       Mix.Task.run("compile")
 

--- a/lib/spark/cheat_sheet.ex
+++ b/lib/spark/cheat_sheet.ex
@@ -319,7 +319,7 @@ defmodule Spark.CheatSheet do
     |> String.replace("|", "\\|")
     |> tap(fn thing ->
       if String.contains?(thing, "\n") do
-        IO.warn("""
+        Spark.Warning.warn("""
         Multi-line DSL option doc detected. Please move contextual information into the
         doc of a section, entity or module.
         #{thing}

--- a/lib/spark/dsl.ex
+++ b/lib/spark/dsl.ex
@@ -606,18 +606,6 @@ defmodule Spark.Dsl do
         def entities(_), do: []
 
         @doc false
-        @spec entities_anno(list(atom)) :: list(:erl_anno.anno() | nil)
-        for {path, %{entities_anno: entities_anno}} <- @spark_dsl_config,
-            is_list(path),
-            is_list(entities_anno) do
-          def entities_anno(unquote(path)) do
-            unquote(Macro.escape(entities_anno))
-          end
-        end
-
-        def entities_anno(_), do: []
-
-        @doc false
         for {path, %{opts: opts}} <- @spark_dsl_config, is_list(path) do
           for {key, value} <- opts do
             def fetch_opt(unquote(path), unquote(key)) do
@@ -702,7 +690,6 @@ defmodule Spark.Dsl do
                %{
                  section_anno: section_anno(unquote(path)),
                  entities: entities(unquote(path)),
-                 entities_anno: entities_anno(unquote(path)),
                  opts: section_opts(unquote(path)),
                  opts_anno: opts_anno(unquote(path))
                }
@@ -768,9 +755,7 @@ defmodule Spark.Dsl do
               ),
             opts_anno:
               Keyword.merge(left_config[:opts_anno] || [], right_config[:opts_anno] || []),
-            section_anno: right_config[:section_anno] || left_config[:section_anno],
-            entities_anno:
-              (left_config[:entities_anno] || []) ++ (right_config[:entities_anno] || [])
+            section_anno: right_config[:section_anno] || left_config[:section_anno]
           }
       end)
     end)

--- a/lib/spark/dsl/entity.ex
+++ b/lib/spark/dsl/entity.ex
@@ -300,6 +300,14 @@ defmodule Spark.Dsl.Entity do
       metadata = %Spark.Dsl.Entity.Meta{anno: anno, properties_anno: opts_anno}
       %{built | __spark_metadata__: metadata}
     else
+      Spark.Warning.warn_deprecated(
+        "Entity without __spark_metadata__ field",
+        "Entity #{inspect(built.__struct__)} does not define a `__spark_metadata__` field. " <>
+          "This field is required to access source annotations. " <>
+          "Add `__spark_metadata__: nil` to the defstruct for #{inspect(built.__struct__)}.",
+        anno
+      )
+
       built
     end
   end

--- a/lib/spark/dsl/entity/meta.ex
+++ b/lib/spark/dsl/entity/meta.ex
@@ -1,0 +1,8 @@
+defmodule Spark.Dsl.Entity.Meta do
+  @moduledoc false
+
+  defstruct [
+    :anno,
+    properties_anno: %{}
+  ]
+end

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -1305,12 +1305,13 @@ defmodule Spark.Dsl.Extension do
                 nested_key: nested_key,
                 mod: mod
               ] do
-          def __build__(module, opts, nested_entities, anno) do
+          def __build__(module, opts, nested_entities, anno, opts_anno) do
             case Spark.Dsl.Entity.build(
                    unquote(Macro.escape(entity)),
                    opts,
                    nested_entities,
-                   anno
+                   anno,
+                   opts_anno
                  ) do
               {:ok, built} ->
                 built
@@ -1597,7 +1598,8 @@ defmodule Spark.Dsl.Extension do
               Spark.Dsl.Extension.EntityOption.set_entity_option(
                 __MODULE__,
                 unquote(key),
-                unquote(value)
+                unquote(value),
+                unquote(Spark.Dsl.Extension.macro_env_anno(__CALLER__, nil))
               )
             end
           end

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -258,69 +258,6 @@ defmodule Spark.Dsl.Extension do
     )
   end
 
-  @doc """
-  Get the annotation for an entity at the specified path and index.
-
-  Entities are stored in order, so the index corresponds to the position
-  in the entities list (0-based indexing).
-  """
-  @spec get_entity_anno(map | module, atom | list(atom), integer) :: :erl_anno.anno() | nil
-  def get_entity_anno(dsl_state, path, index)
-
-  def get_entity_anno(%struct{}, path, index) do
-    get_entity_anno(struct, path, index)
-  end
-
-  def get_entity_anno(map, path, index) when not is_list(path) do
-    get_entity_anno(map, [path], index)
-  end
-
-  def get_entity_anno(map, path, index) when is_map(map) do
-    Spark.Dsl.Transformer.get_entity_anno(map, path, index)
-  end
-
-  def get_entity_anno(resource, path, index) do
-    get_config_entry_with_fallback(
-      resource,
-      path,
-      fn -> resource.entity_anno(path, index) end,
-      :entities_anno,
-      &Enum.at(&1, index),
-      &Spark.Dsl.Transformer.get_entity_anno(&1, path, index)
-    )
-  end
-
-  @doc """
-  Get all entity annotations for the specified path.
-
-  Returns a list of annotations in the same order as the entities.
-  """
-  @spec get_entities_anno(map | module, atom | list(atom)) :: list(:erl_anno.anno() | nil)
-  def get_entities_anno(dsl_state, path)
-
-  def get_entities_anno(%struct{}, path) do
-    get_entities_anno(struct, path)
-  end
-
-  def get_entities_anno(map, path) when not is_list(path) do
-    get_entities_anno(map, [path])
-  end
-
-  def get_entities_anno(map, path) when is_map(map) do
-    Spark.Dsl.Transformer.get_entities_anno(map, path)
-  end
-
-  def get_entities_anno(resource, path) do
-    get_config_entry_with_fallback(
-      resource,
-      path,
-      fn -> resource.entities_anno(path) end,
-      :entities_anno,
-      & &1,
-      &Spark.Dsl.Transformer.get_entities_anno(&1, path)
-    )
-  end
-
   @doc "Get a value that was persisted while transforming or compiling the resource, e.g `:primary_key`"
   def get_persisted(resource, key, default \\ nil)
 
@@ -2066,7 +2003,6 @@ defmodule Spark.Dsl.Extension do
   @spec default_section_config() :: %{
           section_anno: :erl_anno.anno() | nil,
           entities: list(),
-          entities_anno: list(:erl_anno.anno() | nil),
           opts: Keyword.t(),
           opts_anno: Keyword.t(:erl_anno.anno() | nil)
         }
@@ -2074,7 +2010,6 @@ defmodule Spark.Dsl.Extension do
     do: %{
       section_anno: nil,
       entities: [],
-      entities_anno: [],
       opts: [],
       opts_anno: []
     }

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -176,6 +176,64 @@ defmodule Spark.Dsl.Extension do
       mod.module_info(:attributes)[attr]
   end
 
+  @doc """
+  Get the annotation for a section at the given path.
+  """
+  @spec get_section_anno(map | module, atom | list(atom)) :: :erl_anno.anno() | nil
+  def get_section_anno(dsl_state, path)
+
+  def get_section_anno(%struct{}, path) do
+    get_section_anno(struct, path)
+  end
+
+  def get_section_anno(map, path) when not is_list(path) do
+    get_section_anno(map, [path])
+  end
+
+  def get_section_anno(map, path) when is_map(map) do
+    Spark.Dsl.Transformer.get_section_anno(map, path)
+  end
+
+  def get_section_anno(resource, path) do
+    get_config_entry_with_fallback(
+      resource,
+      path,
+      fn -> resource.section_anno(path) end,
+      :section_anno,
+      & &1,
+      &Spark.Dsl.Transformer.get_section_anno(&1, path)
+    )
+  end
+
+  @doc """
+  Get the annotation for a specific option in a section.
+  """
+  @spec get_opt_anno(map | module, atom | list(atom), atom) :: :erl_anno.anno() | nil
+  def get_opt_anno(dsl_state, path, opt_name)
+
+  def get_opt_anno(%struct{}, path, opt_name) do
+    get_opt_anno(struct, path, opt_name)
+  end
+
+  def get_opt_anno(map, path, opt_name) when not is_list(path) do
+    get_opt_anno(map, [path], opt_name)
+  end
+
+  def get_opt_anno(map, path, opt_name) when is_map(map) do
+    Spark.Dsl.Transformer.get_opt_anno(map, path, opt_name)
+  end
+
+  def get_opt_anno(resource, path, opt_name) do
+    get_config_entry_with_fallback(
+      resource,
+      path,
+      fn -> resource.opt_anno(path, opt_name) end,
+      :opts_anno,
+      &Keyword.get(&1, opt_name),
+      &Spark.Dsl.Transformer.get_opt_anno(&1, path, opt_name)
+    )
+  end
+
   @doc "Get the entities configured for a given section"
   def get_entities(map, nil), do: get_entities(map, [])
 
@@ -190,31 +248,77 @@ defmodule Spark.Dsl.Extension do
   end
 
   def get_entities(resource, path) do
-    resource.entities(path)
-  rescue
-    _ in [UndefinedFunctionError, ArgumentError] ->
-      try do
-        case Process.get({resource, :spark, path}) do
-          %{entities: entities} ->
-            entities
+    get_config_entry_with_fallback(
+      resource,
+      path,
+      fn -> resource.entities(path) end,
+      :entities,
+      & &1,
+      &Spark.Dsl.Transformer.get_entities(&1, path)
+    )
+  end
 
-          _ ->
-            dsl = Module.get_attribute(resource, :spark_dsl_config) || %{}
-            Spark.Dsl.Transformer.get_entities(dsl, path) || []
-        end
-      rescue
-        ArgumentError ->
-          try do
-            resource.entities(path)
-          rescue
-            _ ->
-              reraise ArgumentError,
-                      """
-                      `#{inspect(resource)}` is not a Spark DSL module.
-                      """,
-                      __STACKTRACE__
-          end
-      end
+  @doc """
+  Get the annotation for an entity at the specified path and index.
+
+  Entities are stored in order, so the index corresponds to the position
+  in the entities list (0-based indexing).
+  """
+  @spec get_entity_anno(map | module, atom | list(atom), integer) :: :erl_anno.anno() | nil
+  def get_entity_anno(dsl_state, path, index)
+
+  def get_entity_anno(%struct{}, path, index) do
+    get_entity_anno(struct, path, index)
+  end
+
+  def get_entity_anno(map, path, index) when not is_list(path) do
+    get_entity_anno(map, [path], index)
+  end
+
+  def get_entity_anno(map, path, index) when is_map(map) do
+    Spark.Dsl.Transformer.get_entity_anno(map, path, index)
+  end
+
+  def get_entity_anno(resource, path, index) do
+    get_config_entry_with_fallback(
+      resource,
+      path,
+      fn -> resource.entity_anno(path, index) end,
+      :entities_anno,
+      &Enum.at(&1, index),
+      &Spark.Dsl.Transformer.get_entity_anno(&1, path, index)
+    )
+  end
+
+  @doc """
+  Get all entity annotations for the specified path.
+
+  Returns a list of annotations in the same order as the entities.
+  """
+  @spec get_entities_anno(map | module, atom | list(atom)) :: list(:erl_anno.anno() | nil)
+  def get_entities_anno(dsl_state, path)
+
+  def get_entities_anno(%struct{}, path) do
+    get_entities_anno(struct, path)
+  end
+
+  def get_entities_anno(map, path) when not is_list(path) do
+    get_entities_anno(map, [path])
+  end
+
+  def get_entities_anno(map, path) when is_map(map) do
+    Spark.Dsl.Transformer.get_entities_anno(map, path)
+  end
+
+  def get_entities_anno(resource, path) do
+    get_config_entry_with_fallback(
+      resource,
+      path,
+      fn -> resource.entities_anno(path) end,
+      :entities_anno,
+      & &1,
+      &Spark.Dsl.Transformer.get_entities_anno(&1, path)
+    )
   end
 
   @doc "Get a value that was persisted while transforming or compiling the resource, e.g `:primary_key`"
@@ -304,32 +408,14 @@ defmodule Spark.Dsl.Extension do
   end
 
   defp do_fetch_opt(resource, path, key) do
-    resource.fetch_opt(path, key)
-  rescue
-    _ in [UndefinedFunctionError, ArgumentError] ->
-      try do
-        case Process.get({resource, :spark, :lists.droplast(path)}) do
-          %{options: options} ->
-            Keyword.fetch(options, key)
-
-          _ ->
-            dsl = Module.get_attribute(resource, :spark_dsl_config) || %{}
-
-            Spark.Dsl.Transformer.fetch_option(dsl, path, key)
-        end
-      rescue
-        ArgumentError ->
-          try do
-            resource.fetch_opt(path, key)
-          rescue
-            _ ->
-              reraise ArgumentError,
-                      """
-                      `#{inspect(resource)}` is not a Spark DSL module.
-                      """,
-                      __STACKTRACE__
-          end
-      end
+    get_config_entry_with_fallback(
+      resource,
+      :lists.droplast(path),
+      fn -> resource.fetch_opt(path, key) end,
+      :options,
+      &Keyword.fetch(&1, key),
+      &Spark.Dsl.Transformer.fetch_option(&1, path, key)
+    )
   end
 
   defdelegate doc(sections, depth \\ 1), to: Spark.CheatSheet
@@ -606,7 +692,7 @@ defmodule Spark.Dsl.Extension do
           {section_path,
            Process.get(
              {__MODULE__, :spark, section_path},
-             %{entities: [], opts: []}
+             Spark.Dsl.Extension.default_section_config()
            )}
         end)
         |> Enum.into(%{})
@@ -860,10 +946,10 @@ defmodule Spark.Dsl.Extension do
         schema = unquote(Macro.escape(Map.get(section, :schema, [])))
 
         dsl_config
-        |> Map.put_new(section_path, %{opts: [], entities: []})
+        |> Map.put_new(section_path, Spark.Dsl.Extension.default_section_config())
         |> Map.update!(section_path, fn config ->
-          Map.update!(config, :opts, fn opts ->
-            case Spark.Options.validate(Keyword.new(opts), schema) do
+          validated_opts =
+            case Spark.Options.validate(Keyword.new(config[:opts] || []), schema) do
               {:ok, opts} ->
                 opts
 
@@ -871,9 +957,12 @@ defmodule Spark.Dsl.Extension do
                 raise Spark.Error.DslError,
                   module: module,
                   message: error,
-                  path: section_path
+                  path: section_path,
+                  location: config[:section_anno]
             end
-          end)
+
+          # Preserve all existing fields, just update opts
+          %{config | opts: validated_opts}
         end)
       end
 
@@ -882,6 +971,8 @@ defmodule Spark.Dsl.Extension do
           opts_module = unquote(opts_module)
           section_path = unquote(path ++ [section.name])
           extension = unquote(extension)
+
+          section_anno = Spark.Dsl.Extension.macro_env_anno(__CALLER__, body[:do])
 
           entity_modules = unquote(entity_modules)
 
@@ -920,6 +1011,18 @@ defmodule Spark.Dsl.Extension do
                       {unquote(extension), unquote(section_path)} | current_sections
                     ])
                   end
+
+                  # Store section annotation
+                  current_config =
+                    Process.get(
+                      {__MODULE__, :spark, unquote(section_path)},
+                      Spark.Dsl.Extension.default_section_config()
+                    )
+
+                  Process.put(
+                    {__MODULE__, :spark, unquote(section_path)},
+                    %{current_config | section_anno: unquote(Macro.escape(section_anno))}
+                  )
 
                   @validate_sections {unquote(section_path), unquote(__MODULE__),
                                       unquote(extension)}
@@ -1069,6 +1172,8 @@ defmodule Spark.Dsl.Extension do
               type = unquote(Macro.escape(config[:type]))
               deprecations = unquote(Macro.escape(section.deprecations))
 
+              opt_anno = Spark.Dsl.Extension.macro_env_anno(__CALLER__, nil)
+
               Spark.Dsl.Extension.maybe_deprecated(
                 field,
                 deprecations,
@@ -1094,7 +1199,8 @@ defmodule Spark.Dsl.Extension do
                   unquote(extension),
                   unquote(section_path),
                   unquote(field),
-                  unquote(value)
+                  unquote(value),
+                  unquote(Macro.escape(opt_anno))
                 )
               end
             end
@@ -1193,8 +1299,13 @@ defmodule Spark.Dsl.Extension do
                 nested_key: nested_key,
                 mod: mod
               ] do
-          def __build__(module, opts, nested_entities) do
-            case Spark.Dsl.Entity.build(unquote(Macro.escape(entity)), opts, nested_entities) do
+          def __build__(module, opts, nested_entities, anno) do
+            case Spark.Dsl.Entity.build(
+                   unquote(Macro.escape(entity)),
+                   opts,
+                   nested_entities,
+                   anno
+                 ) do
               {:ok, built} ->
                 built
 
@@ -1221,7 +1332,8 @@ defmodule Spark.Dsl.Extension do
                 raise Spark.Error.DslError,
                   module: module,
                   message: message,
-                  path: unquote(section_path) ++ additional_path
+                  path: unquote(section_path) ++ additional_path,
+                  location: anno
             end
           end
 
@@ -1244,6 +1356,8 @@ defmodule Spark.Dsl.Extension do
             mod = unquote(mod)
 
             require Spark.Dsl.Extension
+
+            anno = Spark.Dsl.Extension.macro_env_anno(__CALLER__, opts[:do])
 
             Spark.Dsl.Extension.maybe_deprecated(
               entity.name,
@@ -1394,7 +1508,8 @@ defmodule Spark.Dsl.Extension do
                         unquote(entity.recursive_as),
                         unquote(nested_key),
                         unquote(Keyword.delete(opts, :do)),
-                        unquote(arg_values)
+                        unquote(arg_values),
+                        unquote(Macro.escape(anno))
                       )
 
                     unquote(opts[:do])
@@ -1936,5 +2051,100 @@ defmodule Spark.Dsl.Extension do
     sections
     |> Enum.filter(&(&1.name == name))
     |> get_recursive_entities_for_path(rest)
+  end
+
+  @spec default_section_config() :: %{
+          section_anno: :erl_anno.anno() | nil,
+          entities: list(),
+          entities_anno: list(:erl_anno.anno() | nil),
+          opts: Keyword.t(),
+          opts_anno: Keyword.t(:erl_anno.anno() | nil)
+        }
+  def default_section_config,
+    do: %{
+      section_anno: nil,
+      entities: [],
+      entities_anno: [],
+      opts: [],
+      opts_anno: []
+    }
+
+  @spec get_config_entry_with_fallback(
+          module(),
+          list(atom()),
+          (-> result),
+          atom(),
+          (any() -> result),
+          (map() -> result)
+        ) :: result
+        when result: term()
+  defp get_config_entry_with_fallback(
+         resource,
+         path,
+         direct_fn,
+         process_key,
+         process_extractor,
+         transformer_fn
+       ) do
+    direct_fn.()
+  rescue
+    _ in [UndefinedFunctionError, ArgumentError] ->
+      try do
+        case Process.get({resource, :spark, path}) do
+          %{^process_key => value} ->
+            process_extractor.(value)
+
+          _ ->
+            dsl = Module.get_attribute(resource, :spark_dsl_config) || %{}
+            transformer_fn.(dsl)
+        end
+      rescue
+        ArgumentError ->
+          try do
+            direct_fn.()
+          rescue
+            _ ->
+              reraise ArgumentError,
+                      """
+                      `#{inspect(resource)}` is not a Spark DSL module.
+                      """,
+                      __STACKTRACE__
+          end
+      end
+  end
+
+  @spec macro_env_anno(env :: Macro.Env.t(), do_block :: Macro.t()) :: :erl_anno.anno()
+  def macro_env_anno(env, do_block) do
+    anno = :erl_anno.new(env.line)
+    anno = :erl_anno.set_file(String.to_charlist(env.file), anno)
+    maybe_set_end_location(anno, do_block)
+  end
+
+  @spec maybe_set_end_location(:erl_anno.anno(), Macro.t() | nil) :: :erl_anno.anno()
+  if function_exported?(:erl_anno, :set_end_location, 2) do
+    defp maybe_set_end_location(anno, do_block)
+    defp maybe_set_end_location(anno, nil), do: anno
+
+    defp maybe_set_end_location(anno, {_, meta, _}) when is_list(meta) do
+      end_of_expression_meta = Keyword.get(meta, :end_of_expression, [])
+
+      location = ast_meta_to_location(end_of_expression_meta) || ast_meta_to_location(meta)
+
+      if location do
+        :erl_anno.set_end_location(location, anno)
+      else
+        anno
+      end
+    end
+
+    defp ast_meta_to_location(meta) when is_list(meta) do
+      case {Keyword.fetch(meta, :line), Keyword.fetch(meta, :column)} do
+        {{:ok, line}, {:ok, col}} -> {line, col}
+        {{:ok, line}, :error} -> line
+        {:error, :error} -> nil
+      end
+    end
+  else
+    defp maybe_set_end_location(anno, _do_block), do: anno
   end
 end

--- a/lib/spark/dsl/extension/entity.ex
+++ b/lib/spark/dsl/extension/entity.ex
@@ -75,6 +75,7 @@ defmodule Spark.Dsl.Extension.Entity do
       )
 
     opts = Process.delete({:builder_opts, nested_entity_path})
+    opts_anno = Process.delete({:builder_opts_anno, nested_entity_path})
     Process.delete({:builder_anno, nested_entity_path})
 
     nested_entities =
@@ -94,7 +95,7 @@ defmodule Spark.Dsl.Extension.Entity do
         end)
       end)
 
-    built = entity_builder.__build__(module, opts, nested_entities, anno)
+    built = entity_builder.__build__(module, opts, nested_entities, anno, opts_anno)
 
     new_config = %{
       current_config

--- a/lib/spark/dsl/extension/entity.ex
+++ b/lib/spark/dsl/extension/entity.ex
@@ -97,11 +97,7 @@ defmodule Spark.Dsl.Extension.Entity do
 
     built = entity_builder.__build__(module, opts, nested_entities, anno, opts_anno)
 
-    new_config = %{
-      current_config
-      | entities: current_config.entities ++ [built],
-        entities_anno: (current_config.entities_anno || []) ++ [anno]
-    }
+    new_config = %{current_config | entities: current_config.entities ++ [built]}
 
     unless {extension, section_path} in current_sections do
       Process.put({module, :spark_sections}, [

--- a/lib/spark/dsl/extension/entity_option.ex
+++ b/lib/spark/dsl/extension/entity_option.ex
@@ -31,10 +31,14 @@ defmodule Spark.Dsl.Extension.EntityOption do
     current_opts = Process.get({:builder_opts, nested_entity_path}, [])
 
     if Keyword.has_key?(current_opts, key) do
+      # Get the annotation for this entity from the Process store
+      entity_anno = Process.get({:builder_anno, nested_entity_path})
+
       raise Spark.Error.DslError,
         module: module,
         message: "Multiple values for key `#{inspect(key)}`",
-        path: nested_entity_path
+        path: nested_entity_path,
+        location: entity_anno
     end
 
     Process.put(

--- a/lib/spark/dsl/extension/entity_option.ex
+++ b/lib/spark/dsl/extension/entity_option.ex
@@ -26,7 +26,7 @@ defmodule Spark.Dsl.Extension.EntityOption do
     Spark.CodeHelpers.lift_functions(value, field, caller)
   end
 
-  def set_entity_option(module, key, value) do
+  def set_entity_option(module, key, value, anno \\ nil) do
     nested_entity_path = Process.get(:recursive_builder_path)
     current_opts = Process.get({:builder_opts, nested_entity_path}, [])
 
@@ -45,5 +45,15 @@ defmodule Spark.Dsl.Extension.EntityOption do
       {:builder_opts, nested_entity_path},
       Keyword.put(current_opts, key, value)
     )
+
+    # Store property annotation if provided
+    if anno do
+      current_opts_anno = Process.get({:builder_opts_anno, nested_entity_path}, %{})
+
+      Process.put(
+        {:builder_opts_anno, nested_entity_path},
+        Map.put(current_opts_anno, key, anno)
+      )
+    end
   end
 end

--- a/lib/spark/dsl/extension/section_option.ex
+++ b/lib/spark/dsl/extension/section_option.ex
@@ -26,7 +26,7 @@ defmodule Spark.Dsl.Extension.SectionOption do
     Spark.CodeHelpers.lift_functions(value, field, caller)
   end
 
-  def set_section_option(module, extension, section_path, field, value) do
+  def set_section_option(module, extension, section_path, field, value, anno \\ nil) do
     current_sections = Process.get({module, :spark_sections}, [])
 
     unless {extension, section_path} in current_sections do
@@ -38,14 +38,22 @@ defmodule Spark.Dsl.Extension.SectionOption do
     current_config =
       Process.get(
         {module, :spark, section_path},
-        %{entities: [], opts: []}
+        Spark.Dsl.Extension.default_section_config()
       )
+
+    opts_anno =
+      if anno do
+        Keyword.put(current_config[:opts_anno] || [], field, anno)
+      else
+        current_config[:opts_anno] || []
+      end
 
     Process.put(
       {module, :spark, section_path},
       %{
         current_config
-        | opts: Keyword.put(current_config.opts, field, value)
+        | opts: Keyword.put(current_config.opts, field, value),
+          opts_anno: opts_anno
       }
     )
   end

--- a/lib/spark/dsl/transformer.ex
+++ b/lib/spark/dsl/transformer.ex
@@ -13,11 +13,14 @@ defmodule Spark.Dsl.Transformer do
   but keep in mind that no modifications to the dsl structure will be retained, so there is no
   real point in modifying the dsl that you return.
   """
+
+  @type warning() :: String.t() | {String.t(), :erl_anno.anno()}
+
   @callback transform(map) ::
               :ok
               | {:ok, map}
               | {:error, term}
-              | {:warn, map, String.t() | list(String.t())}
+              | {:warn, map, warning() | list(warning())}
               | :halt
   @callback before?(module) :: boolean
   @callback after?(module) :: boolean

--- a/lib/spark/dsl/transformer.ex
+++ b/lib/spark/dsl/transformer.ex
@@ -201,23 +201,61 @@ defmodule Spark.Dsl.Transformer do
   end
 
   def add_entity(dsl_state, path, entity, opts \\ []) do
-    Map.update(dsl_state, path, %{entities: [entity], opts: []}, fn config ->
-      Map.update(config, :entities, [entity], fn entities ->
-        if (opts[:type] || :prepend) == :prepend do
-          [entity | entities]
-        else
-          entities ++ [entity]
-        end
-      end)
-    end)
+    Map.update(
+      dsl_state,
+      path,
+      %{Spark.Dsl.Extension.default_section_config() | entities_anno: [opts[:anno]]},
+      fn config ->
+        config
+        |> Map.update(:entities, [entity], fn entities ->
+          if (opts[:type] || :prepend) == :prepend do
+            [entity | entities]
+          else
+            entities ++ [entity]
+          end
+        end)
+        |> Map.update(:entities_anno, [opts[:anno]], fn entities_anno ->
+          if (opts[:type] || :prepend) == :prepend do
+            [opts[:anno] | entities_anno]
+          else
+            entities_anno ++ [opts[:anno]]
+          end
+        end)
+      end
+    )
   end
 
   def remove_entity(dsl_state, path, func) do
-    Map.update(dsl_state, path, %{entities: [], opts: []}, fn config ->
-      Map.update(config, :entities, [], fn entities ->
-        Enum.reject(entities, func)
-      end)
-    end)
+    Map.update(
+      dsl_state,
+      path,
+      Spark.Dsl.Extension.default_section_config(),
+      fn config ->
+        entities = Map.get(config, :entities, [])
+        entities_anno = Map.get(config, :entities_anno, [])
+
+        # Find indices of entities to remove
+        indices_to_remove =
+          entities
+          |> Enum.with_index()
+          |> Enum.filter(fn {entity, _index} -> func.(entity) end)
+          |> Enum.map(fn {_entity, index} -> index end)
+          # Reverse to remove from end first
+          |> Enum.reverse()
+
+        # Remove entities and their corresponding annotations
+        updated_entities = Enum.reject(entities, func)
+
+        updated_entities_anno =
+          Enum.reduce(indices_to_remove, entities_anno, fn index, acc ->
+            List.delete_at(acc, index)
+          end)
+
+        config
+        |> Map.put(:entities, updated_entities)
+        |> Map.put(:entities_anno, updated_entities_anno)
+      end
+    )
   end
 
   def get_entities(dsl_state, path) do
@@ -228,15 +266,56 @@ defmodule Spark.Dsl.Transformer do
 
   def fetch_option(dsl_state, path, option) do
     dsl_state
-    |> Map.get(path, %{opts: []})
+    |> Map.get(path, Spark.Dsl.Extension.default_section_config())
     |> Map.get(:opts)
     |> Kernel.||([])
     |> Keyword.fetch(option)
   end
 
+  @spec get_section_anno(map, list(atom)) :: :erl_anno.anno() | nil
+  def get_section_anno(dsl_state, path) do
+    dsl_state
+    |> Map.get(path, %{})
+    |> Map.get(:section_anno)
+  end
+
+  @spec get_opt_anno(map, list(atom), atom) :: :erl_anno.anno() | nil
+  def get_opt_anno(dsl_state, path, option) do
+    dsl_state
+    |> Map.get(path, Spark.Dsl.Extension.default_section_config())
+    |> Map.get(:opts_anno, [])
+    |> Keyword.get(option)
+  end
+
+  @doc """
+  Gets the annotation for an entity at the specified path and index.
+
+  Entities are stored in order, so the index corresponds to the position
+  in the entities list (0-based indexing).
+  """
+  @spec get_entity_anno(map, list(atom), integer) :: :erl_anno.anno() | nil
+  def get_entity_anno(dsl_state, path, index) do
+    dsl_state
+    |> Map.get(path, Spark.Dsl.Extension.default_section_config())
+    |> Map.get(:entities_anno, [])
+    |> Enum.at(index)
+  end
+
+  @doc """
+  Gets all entity annotations for the specified path.
+
+  Returns a list of annotations in the same order as the entities.
+  """
+  @spec get_entities_anno(map, list(atom)) :: list(:erl_anno.anno() | nil)
+  def get_entities_anno(dsl_state, path) do
+    dsl_state
+    |> Map.get(path, Spark.Dsl.Extension.default_section_config())
+    |> Map.get(:entities_anno, [])
+  end
+
   def get_option(dsl_state, path, option, default \\ nil) do
     dsl_state
-    |> Map.get(path, %{opts: []})
+    |> Map.get(path, Spark.Dsl.Extension.default_section_config())
     |> Map.get(:opts)
     |> Kernel.||([])
     |> Keyword.get(option, default)
@@ -244,10 +323,11 @@ defmodule Spark.Dsl.Transformer do
 
   def set_option(dsl_state, path, option, value) do
     dsl_state
-    |> Map.put_new(path, %{opts: []})
+    |> Map.put_new(path, Spark.Dsl.Extension.default_section_config())
     |> Map.update!(path, fn existing_opts ->
       existing_opts
       |> Map.put_new(:opts, [])
+      |> Map.put_new(:opts_anno, [])
       |> Map.update!(:opts, fn opts ->
         Keyword.put(opts, option, value)
       end)

--- a/lib/spark/dsl/verifier.ex
+++ b/lib/spark/dsl/verifier.ex
@@ -4,10 +4,13 @@ defmodule Spark.Dsl.Verifier do
 
   In a verifier, you can reference and depend on other modules without causing compile time dependencies.
   """
+
+  @type warning() :: String.t() | {String.t(), :erl_anno.anno()}
+
   @callback verify(map) ::
               :ok
               | {:error, term}
-              | {:warn, String.t() | list(String.t())}
+              | {:warn, warning() | list(warning())}
 
   defmacro __using__(_) do
     quote generated: true do

--- a/lib/spark/dsl/verifiers/verify_entity_uniqueness.ex
+++ b/lib/spark/dsl/verifiers/verify_entity_uniqueness.ex
@@ -94,30 +94,54 @@ defmodule Spark.Dsl.Verifiers.VerifyEntityUniqueness do
   end
 
   defp do_verify_entity_uniqueness(module, entity, section_path, dsl_state) do
-    dsl_state
-    |> Verifier.get_entities(section_path)
-    |> Enum.filter(&(&1.__struct__ == entity.target))
-    |> unique_entities_or_error(entity.identifier, module, section_path)
+    entities =
+      dsl_state
+      |> Verifier.get_entities(section_path)
+      |> Enum.filter(&(&1.__struct__ == entity.target))
+
+    entities_anno = Spark.Dsl.Transformer.get_entities_anno(dsl_state, section_path)
+
+    unique_entities_or_error(entities, entity.identifier, module, section_path, entities_anno)
   end
 
-  defp unique_entities_or_error(_, nil, _, _), do: :ok
+  defp unique_entities_or_error(entities_to_check, identifier, module, path, entities_anno \\ [])
+  defp unique_entities_or_error(_, nil, _, _, _), do: :ok
 
-  defp unique_entities_or_error(entities_to_check, identifier, module, path) do
-    entities_to_check
-    |> Enum.frequencies_by(&{get_identifier(&1, identifier), &1.__struct__})
-    |> Enum.find_value(fn {key, value} ->
-      if value > 1 do
-        key
-      end
-    end)
-    |> case do
+  defp unique_entities_or_error(entities_to_check, identifier, module, path, entities_anno) do
+    # Build a map of entity to its index to track annotations
+    entity_index_map =
+      entities_to_check
+      |> Enum.with_index()
+      |> Map.new(fn {entity, index} -> {entity, index} end)
+
+    duplicate_result =
+      entities_to_check
+      |> Enum.frequencies_by(&{get_identifier(&1, identifier), &1.__struct__})
+      |> Enum.find_value(fn {key, value} ->
+        if value > 1 do
+          # Find the first duplicate entity to get its location
+          duplicate_entity =
+            Enum.find(entities_to_check, fn entity ->
+              {get_identifier(entity, identifier), entity.__struct__} == key
+            end)
+
+          {key, duplicate_entity}
+        end
+      end)
+
+    case duplicate_result do
       nil ->
         :ok
 
-      {identifier, target} ->
+      {{identifier, target}, duplicate_entity} ->
+        # Get the annotation for the duplicate entity
+        entity_index = Map.get(entity_index_map, duplicate_entity)
+        location = if entity_index, do: Enum.at(entities_anno, entity_index)
+
         raise Spark.Error.DslError,
           module: module,
           path: path ++ [identifier],
+          location: location,
           message: """
           Got duplicate #{inspect(target)}: #{identifier}
           """

--- a/lib/spark/options/options.ex
+++ b/lib/spark/options/options.ex
@@ -862,7 +862,7 @@ defmodule Spark.Options do
     case Keyword.fetch(schema, key) do
       {:ok, schema} ->
         if message = Keyword.get(schema, :deprecated) do
-          IO.warn("#{render_key(key)} is deprecated. " <> message)
+          Spark.Warning.warn_deprecated("#{render_key(key)}", message)
         end
 
         {:ok, value, schema}

--- a/lib/spark/options/validator.ex
+++ b/lib/spark/options/validator.ex
@@ -124,8 +124,9 @@ defmodule Spark.Options.Validator do
 
         if define_deprecated_access? do
           def fetch(%__MODULE__{} = data, key) do
-            IO.warn(
-              "Accessing options from #{__MODULE__} is deprecated. Use `opts.#{key}` instead."
+            Spark.Warning.warn_deprecated(
+              "Accessing options from #{__MODULE__}",
+              "Use `opts.#{key}` instead."
             )
 
             Map.fetch(data, key)
@@ -299,7 +300,10 @@ defmodule Spark.Options.Validator do
 
         for {key, config} <- Keyword.new(schema), config[:deprecated] do
           defp warn_deprecated(unquote(key)) do
-            IO.warn("#{unquote(key)} is deprecated")
+            Spark.Warning.warn_deprecated(
+              "#{unquote(key)}",
+              "Use `opts.#{unquote(key)}` instead."
+            )
           end
         end
 

--- a/lib/spark/warning.ex
+++ b/lib/spark/warning.ex
@@ -1,0 +1,116 @@
+defmodule Spark.Warning do
+  @moduledoc false
+
+  @type location :: :erl_anno.anno()
+  @type stacktrace :: Exception.stacktrace() | Macro.Env.t()
+  @type warning_message :: String.t() | term()
+  @type warning_item :: warning_message() | {warning_message(), location()}
+
+  @doc """
+  Emits a warning with optional location information.
+
+  ## Parameters
+
+  - `message` - The warning message (string or any term)
+  - `location` - Optional erl_anno location information
+  - `stacktrace` - Optional stacktrace (defaults to current stacktrace)
+
+  ## Examples
+
+      # Simple warning without location
+      Spark.Warning.warn("This is deprecated", nil, __ENV__)
+
+      # Warning with location annotation
+      Spark.Warning.warn("Invalid configuration", location, __ENV__)
+
+      # Warning with custom stacktrace
+      Spark.Warning.warn("Something went wrong", nil, custom_stacktrace)
+  """
+  @spec warn(warning_message(), location() | nil, stacktrace() | nil) :: :ok
+  def warn(message, location \\ nil, stacktrace \\ nil)
+
+  def warn(message, location, stacktrace) when is_binary(message) do
+    formatted_message = format_warning_message(message, location)
+
+    warn_context =
+      if location do
+        warn_context =
+          case :erl_anno.file(location) do
+            :undefined -> [file: "unknown_file"]
+            file -> [file: Path.relative_to_cwd(to_string(file))]
+          end
+
+        case :erl_anno.location(location) do
+          {line, column} -> Keyword.merge(warn_context, line: line, column: column)
+          line -> Keyword.merge(warn_context, line: line)
+        end
+      else
+        stacktrace || get_filtered_stacktrace()
+      end
+
+    IO.warn(formatted_message, warn_context)
+  end
+
+  def warn(message, location, stacktrace) do
+    warn(inspect(message), location, stacktrace)
+  end
+
+  @doc """
+  Emits a deprecation warning with optional location information.
+
+  ## Parameters
+
+  - `item` - The deprecated item (string)
+  - `message` - Additional deprecation message (optional)
+  - `location` - Optional erl_anno location information
+  - `stacktrace` - Optional stacktrace (defaults to current stacktrace)
+
+  ## Examples
+
+      Spark.Warning.warn_deprecated("old_option")
+      Spark.Warning.warn_deprecated("old_option", "Use new_option instead", location)
+  """
+  @spec warn_deprecated(String.t(), String.t() | nil, location() | nil, stacktrace() | nil) :: :ok
+  def warn_deprecated(item, message \\ nil, location \\ nil, stacktrace \\ nil) do
+    base_message = "#{item} is deprecated"
+
+    full_message =
+      if message do
+        base_message <> ". " <> message
+      else
+        base_message
+      end
+
+    warn(full_message, location, stacktrace)
+  end
+
+  @spec format_warning_message(String.t(), location() | nil) :: String.t()
+  defp format_warning_message(message, nil), do: message
+
+  defp format_warning_message(message, location) do
+    location_info = get_location_info(location)
+    "#{message}#{location_info}"
+  end
+
+  @spec get_location_info(location()) :: String.t()
+  defp get_location_info(location) do
+    file =
+      case :erl_anno.file(location) do
+        :undefined -> "unknown_file"
+        file -> Path.relative_to_cwd(to_string(file))
+      end
+
+    case :erl_anno.location(location) do
+      {line, column} -> " (defined in #{Exception.format_file_line_column(file, line, column)})"
+      line -> " (defined in #{Exception.format_file_line(file, line)})"
+    end
+  end
+
+  @spec get_filtered_stacktrace() :: [term()]
+  defp get_filtered_stacktrace do
+    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+
+    # Remove the latest 2 frames to exclude this Warning module's calls
+    stacktrace |> Enum.drop(3)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,13 @@ defmodule Spark.MixProject do
       app: :spark,
       version: @version,
       elixir: "~> 1.15",
+      elixirc_options: [
+        warnings_as_errors: true,
+        parser_options: [
+          token_metadata: true,
+          parser_columns: true
+        ]
+      ],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -68,6 +75,7 @@ defmodule Spark.MixProject do
         "documentation/how_to/upgrade-to-2.0.md",
         "documentation/how_to/writing-extensions.md",
         "documentation/how_to/split-up-large-dsls.md",
+        "documentation/how_to/use-source-annotations.md",
         "documentation/tutorials/get-started-with-spark.md"
       ],
       groups_for_extras: [

--- a/test/cross_extension_recursive_patch_test.exs
+++ b/test/cross_extension_recursive_patch_test.exs
@@ -12,7 +12,7 @@ defmodule CrossExtensionPatchTest do
 
   defmodule Argument do
     @moduledoc false
-    defstruct name: nil, value: nil
+    defstruct name: nil, value: nil, __spark_metadata__: nil
 
     def entity do
       %Spark.Dsl.Entity{
@@ -30,7 +30,7 @@ defmodule CrossExtensionPatchTest do
 
   defmodule Step do
     @moduledoc false
-    defstruct name: nil, steps: [], arguments: []
+    defstruct name: nil, steps: [], arguments: [], __spark_metadata__: nil
 
     def entity(name) do
       %Spark.Dsl.Entity{
@@ -51,7 +51,7 @@ defmodule CrossExtensionPatchTest do
 
   defmodule Input do
     @moduledoc false
-    defstruct name: nil
+    defstruct name: nil, __spark_metadata__: nil
 
     def entity do
       %Spark.Dsl.Entity{

--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -345,6 +345,327 @@ defmodule Spark.DslTest do
         end
       end
     end
+  end
+
+  describe "annotation tracking" do
+    test "section annotations are captured" do
+      base_line = __ENV__.line
+
+      defmodule SectionAnnoTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        presets do
+          preset(:test_preset)
+        end
+
+        contact do
+          module(Some.Module)
+        end
+      end
+
+      dsl_state = SectionAnnoTest.spark_dsl_config()
+
+      # Check section annotation for :presets (sections are stored with list keys)
+      presets_anno = Spark.Dsl.Extension.get_section_anno(dsl_state, [:presets])
+      assert presets_anno != nil
+      assert :erl_anno.location(presets_anno) == base_line + 6
+      assert :erl_anno.file(presets_anno) == String.to_charlist(__ENV__.file)
+
+      # Check section annotation for :contact
+      contact_anno = Spark.Dsl.Extension.get_section_anno(dsl_state, [:contact])
+      assert contact_anno != nil
+      assert :erl_anno.location(contact_anno) == base_line + 10
+      assert :erl_anno.file(contact_anno) == String.to_charlist(__ENV__.file)
+
+      # Check end_location if available (OTP 28+)
+      if function_exported?(:erl_anno, :end_location, 1) do
+        presets_end = :erl_anno.end_location(presets_anno)
+        contact_end = :erl_anno.end_location(contact_anno)
+
+        # Sections should have end locations that are at or after their start
+        assert presets_end >= base_line + 6
+        assert contact_end >= base_line + 10
+      end
+    end
+
+    test "option annotations are captured as keyword list" do
+      base_line = __ENV__.line
+
+      defmodule OptionAnnoTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        personal_details do
+          first_name("John")
+          last_name("Doe")
+          # Line offset: +10
+          nicknames([
+            "Johnny",
+            "J-Dog"
+          ])
+        end
+
+        contact do
+          module(Some.Module)
+        end
+      end
+
+      dsl_state = OptionAnnoTest.spark_dsl_config()
+
+      # Check option annotations for personal_details using introspection functions
+      first_name_anno =
+        Spark.Dsl.Extension.get_opt_anno(dsl_state, [:personal_details], :first_name)
+
+      assert first_name_anno != nil
+      assert :erl_anno.location(first_name_anno) == base_line + 7
+      assert :erl_anno.file(first_name_anno) == String.to_charlist(__ENV__.file)
+
+      last_name_anno =
+        Spark.Dsl.Extension.get_opt_anno(dsl_state, [:personal_details], :last_name)
+
+      assert last_name_anno != nil
+      assert :erl_anno.location(last_name_anno) == base_line + 8
+      assert :erl_anno.file(last_name_anno) == String.to_charlist(__ENV__.file)
+
+      nicknames_anno =
+        Spark.Dsl.Extension.get_opt_anno(dsl_state, [:personal_details], :nicknames)
+
+      assert nicknames_anno != nil
+      assert :erl_anno.location(nicknames_anno) == base_line + 10
+
+      # Options don't have end locations since they're passed as a value and not
+      # as AST
+
+      # Check option annotations for contact
+      module_anno = Spark.Dsl.Extension.get_opt_anno(dsl_state, [:contact], :module)
+      assert module_anno != nil
+      assert :erl_anno.location(module_anno) == base_line + 17
+    end
+
+    test "entities capture exact file and line information" do
+      base_line = __ENV__.line
+
+      defmodule EntityAnnoTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        presets do
+          # Line offset: +8
+          preset :first do
+            default_message("first")
+          end
+
+          # Line offset: +13
+          preset :second do
+            default_message("second")
+          end
+        end
+      end
+
+      dsl_state = EntityAnnoTest.spark_dsl_config()
+      entities = Spark.Dsl.Extension.get_entities(dsl_state, [:presets])
+
+      [first, second] = Enum.sort_by(entities, & &1.name)
+
+      assert :erl_anno.location(first.anno) == base_line + 8
+      assert :erl_anno.location(second.anno) == base_line + 13
+
+      assert :erl_anno.file(first.anno) == String.to_charlist(__ENV__.file)
+      assert :erl_anno.file(second.anno) == String.to_charlist(__ENV__.file)
+    end
+
+    test "nested entities capture annotations" do
+      base_line = __ENV__.line
+
+      defmodule NestedEntityAnnoTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        presets do
+          # Line offset: +8
+          preset :parent do
+            # Line offset: +10
+            singleton(:child_entity)
+          end
+        end
+      end
+
+      dsl_state = NestedEntityAnnoTest.spark_dsl_config()
+      [entity | _] = Spark.Dsl.Extension.get_entities(dsl_state, [:presets])
+
+      assert :erl_anno.location(entity.anno) == base_line + 8
+      assert :erl_anno.file(entity.anno) == String.to_charlist(__ENV__.file)
+
+      assert :erl_anno.location(entity.singleton.anno) == base_line + 10
+      assert :erl_anno.file(entity.singleton.anno) == String.to_charlist(__ENV__.file)
+    end
+
+    test "annotations include end_location when available (OTP 28+)" do
+      base_line = __ENV__.line
+
+      defmodule EndLocationTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        presets do
+          # Line offset: +8
+          preset :with_block do
+            default_message("start")
+            # more content
+          end
+
+          # Line offset: +14
+        end
+      end
+
+      dsl_state = EndLocationTest.spark_dsl_config()
+      entities = Spark.Dsl.Extension.get_entities(dsl_state, [:presets])
+
+      [entity | _] = entities
+      assert :erl_anno.location(entity.anno) == base_line + 8
+
+      # Check if end_location is supported and set
+      if function_exported?(:erl_anno, :set_end_location, 1) do
+        end_location = :erl_anno.end_location(entity.anno)
+
+        # Should be at or after start
+        assert end_location >= base_line + 8
+        # Should be before end
+        assert end_location <= base_line + 14
+      end
+    end
+
+    test "fragments preserve original source location annotations" do
+      # Test with the existing TedDansenFragment which defines address options
+      dsl_state = TedDansen.spark_dsl_config()
+
+      # Check that the fragment's configuration is included
+      {:ok, street} = TedDansen.fetch_opt([:address], :street)
+      assert street == "foobar"
+
+      # Create a test with entities in fragments
+      defmodule TestFragment do
+        @moduledoc false
+        use Spark.Dsl.Fragment, of: Spark.Test.Contact
+
+        presets do
+          # Line 6 in this context
+          preset :fragment_preset do
+            default_message("from fragment")
+          end
+        end
+      end
+
+      defmodule TestWithFragment do
+        @moduledoc false
+        use Spark.Test.Contact, fragments: [TestFragment]
+
+        presets do
+          preset :main_preset do
+            default_message("from main")
+          end
+        end
+      end
+
+      dsl_state = TestWithFragment.spark_dsl_config()
+      entities = Spark.Dsl.Extension.get_entities(dsl_state, [:presets])
+
+      assert length(entities) == 2
+
+      fragment_entity = Enum.find(entities, &(&1.name == :fragment_preset))
+      main_entity = Enum.find(entities, &(&1.name == :main_preset))
+
+      assert String.to_charlist(__ENV__.file) == :erl_anno.file(fragment_entity.anno)
+      assert String.to_charlist(__ENV__.file) == :erl_anno.file(main_entity.anno)
+    end
+
+    test "introspection functions can extract annotations" do
+      base_line = __ENV__.line
+
+      defmodule IntrospectionTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        personal_details do
+          first_name("Alice")
+          last_name("Smith")
+        end
+
+        presets do
+          preset(:test_preset)
+        end
+      end
+
+      dsl_state = IntrospectionTest.spark_dsl_config()
+
+      # Test get_section_anno function
+      personal_details_anno = Spark.Dsl.Extension.get_section_anno(dsl_state, [:personal_details])
+      assert :erl_anno.location(personal_details_anno) == base_line + 6
+      assert :erl_anno.file(personal_details_anno) == String.to_charlist(__ENV__.file)
+
+      # Test get_opt_anno function
+      first_name_anno =
+        Spark.Dsl.Extension.get_opt_anno(dsl_state, [:personal_details], :first_name)
+
+      assert :erl_anno.location(first_name_anno) == base_line + 7
+
+      last_name_anno =
+        Spark.Dsl.Extension.get_opt_anno(dsl_state, [:personal_details], :last_name)
+
+      assert :erl_anno.location(last_name_anno) == base_line + 8
+
+      # Test get_entities_with_anno returns entities with their annotations intact
+      entities = Spark.Dsl.Extension.get_entities(dsl_state, [:presets])
+      assert length(entities) == 1
+      [entity] = entities
+      assert :erl_anno.location(entity.anno) == base_line + 12
+    end
+
+    test "entity annotations can be accessed via introspection regardless of anno_field" do
+      base_line = __ENV__.line
+
+      defmodule EntityIntrospectionTest do
+        @moduledoc false
+        use Spark.Test.Contact
+
+        presets do
+          # Line offset: +8
+          preset :first do
+            default_message("first")
+          end
+
+          # Line offset: +13
+          preset :second do
+            default_message("second")
+          end
+        end
+      end
+
+      dsl_state = EntityIntrospectionTest.spark_dsl_config()
+
+      # Test get_entities_anno function - gets all annotations
+      entities_anno = Spark.Dsl.Extension.get_entities_anno(dsl_state, [:presets])
+      assert length(entities_anno) == 2
+
+      [first_anno, second_anno] = entities_anno
+      assert first_anno != nil
+      assert second_anno != nil
+      assert :erl_anno.location(first_anno) == base_line + 8
+      assert :erl_anno.location(second_anno) == base_line + 13
+
+      # Test get_entity_anno function - gets specific annotation by index
+      first_entity_anno = Spark.Dsl.Extension.get_entity_anno(dsl_state, [:presets], 0)
+      second_entity_anno = Spark.Dsl.Extension.get_entity_anno(dsl_state, [:presets], 1)
+
+      assert :erl_anno.location(first_entity_anno) == base_line + 8
+      assert :erl_anno.location(second_entity_anno) == base_line + 13
+
+      # Test that annotations are available even for entities without anno_field
+      # (since not all entity types define an anno_field)
+      assert first_entity_anno != nil
+      assert second_entity_anno != nil
+    end
 
     test "entities with required arguments don't assume an argument is opts if its a keyword list" do
       defmodule BethSanchez do
@@ -533,6 +854,52 @@ defmodule Spark.DslTest do
       end
 
       assert :default == Spark.Dsl.Extension.get_opt(NoOptionSet, [:example], :opt_with_default)
+    end
+  end
+
+  describe "error location tracking" do
+    test "duplicate entity errors include location information" do
+      import ExUnit.CaptureIO
+
+      error_output =
+        capture_io(:stderr, fn ->
+          try do
+            defmodule LocationTestDuplicate do
+              use Spark.Test.Contact
+
+              presets do
+                preset(:duplicate_test)
+                preset(:duplicate_test)
+              end
+            end
+          rescue
+            _ -> :ok
+          end
+        end)
+
+      # Should include the file and line information
+      assert error_output =~ "dsl_test.exs"
+      assert error_output =~ "Got duplicate"
+    end
+
+    test "schema validation errors include location information" do
+      try do
+        defmodule LocationTestSchema do
+          use Spark.Dsl.Fragment, of: Spark.Test.Contact
+
+          personal_details do
+            # This should trigger a schema validation error during compilation
+            # when the section is processed, because first_name is required
+          end
+        end
+
+        _ = LocationTestSchema.spark_dsl_config()
+      rescue
+        error ->
+          # The error should include location information
+          error_message = Exception.message(error)
+          assert error_message =~ "dsl_test.exs"
+      end
     end
   end
 end

--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -284,16 +284,24 @@ defmodule Spark.DslTest do
     test "verifiers are run" do
       import ExUnit.CaptureIO
 
-      assert capture_io(:stderr, fn ->
-               defmodule Gandalf do
-                 @moduledoc false
-                 use Spark.Test.Contact
+      base_line = __ENV__.line
 
-                 personal_details do
-                   first_name("Gandalf")
-                 end
-               end
-             end) =~ "Cannot be gandalf"
+      message =
+        capture_io(:stderr, fn ->
+          defmodule Gandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              # Line offset: +10
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert message =~ "Cannot be gandalf"
+      assert message =~ "(defined in test/dsl_test.exs:#{base_line + 10}:)"
+      assert message =~ "~~~"
     end
 
     test "extensions can add entities to other entities extensions" do

--- a/test/support/contact/contact.ex
+++ b/test/support/contact/contact.ex
@@ -65,21 +65,20 @@ defmodule Spark.Test.Contact do
         :thing,
         :singleton,
         :__identifier__,
-        :anno,
+        :__spark_metadata__,
         special?: false
       ]
     end
 
     defmodule Singleton do
       @moduledoc false
-      defstruct [:value, :anno]
+      defstruct [:value, :__spark_metadata__]
     end
 
     @singleton %Spark.Dsl.Entity{
       name: :singleton,
       args: [:value],
       target: Singleton,
-      anno_field: :anno,
       schema: [
         value: [
           type: :any
@@ -111,7 +110,6 @@ defmodule Spark.Test.Contact do
       args: [:name],
       target: Preset,
       identifier: :name,
-      anno_field: :anno,
       entities: [
         singleton: [@singleton]
       ],

--- a/test/support/contact/contact.ex
+++ b/test/support/contact/contact.ex
@@ -38,6 +38,10 @@ defmodule Spark.Test.Contact do
         contact: [
           type: :string,
           doc: "Added to incur a conflict between this and the `contact` top level section."
+        ],
+        nicknames: [
+          type: {:list, :string},
+          doc: "A list of nicknames for this contact"
         ]
       ]
     }
@@ -61,19 +65,21 @@ defmodule Spark.Test.Contact do
         :thing,
         :singleton,
         :__identifier__,
+        :anno,
         special?: false
       ]
     end
 
     defmodule Singleton do
       @moduledoc false
-      defstruct [:value]
+      defstruct [:value, :anno]
     end
 
     @singleton %Spark.Dsl.Entity{
       name: :singleton,
       args: [:value],
       target: Singleton,
+      anno_field: :anno,
       schema: [
         value: [
           type: :any
@@ -105,6 +111,7 @@ defmodule Spark.Test.Contact do
       args: [:name],
       target: Preset,
       identifier: :name,
+      anno_field: :anno,
       entities: [
         singleton: [@singleton]
       ],

--- a/test/support/contact/verifiers/verify_not_gandalf.ex
+++ b/test/support/contact/verifiers/verify_not_gandalf.ex
@@ -9,7 +9,8 @@ defmodule Spark.Test.Contact.Verifiers.VerifyNotGandalf do
        Spark.Error.DslError.exception(
          message: "Cannot be gandalf",
          path: [:personal_details, :first_name],
-         module: Verifier.get_persisted(dsl, :module)
+         module: Verifier.get_persisted(dsl, :module),
+         location: Spark.Dsl.Transformer.get_opt_anno(dsl, [:personal_details], :first_name)
        )}
     else
       :ok

--- a/test/support/recursive/atom.ex
+++ b/test/support/recursive/atom.ex
@@ -1,4 +1,4 @@
 defmodule Spark.Test.Atom do
   @moduledoc false
-  defstruct [:name]
+  defstruct [:name, :__spark_metadata__]
 end

--- a/test/support/recursive/step.ex
+++ b/test/support/recursive/step.ex
@@ -1,4 +1,4 @@
 defmodule Spark.Test.Step do
   @moduledoc false
-  defstruct [:name, :number, :__identifier__, steps: []]
+  defstruct [:name, :number, :__identifier__, :__spark_metadata__, steps: []]
 end


### PR DESCRIPTION
Implements #65

# Features

* Provides Introspection Function to retrieve `erl_anno` for sections, section options, entities, and entity properties
* Adds location to DslError and provides it where feasible
* Adds `Spark.Warning` (internal) for emitting warnings. Supports intentional locations as well as stacktraces.

# Missing / Incomplete

* End Of Expression Locations require `token_metadata` parser option to be enabled.
* Start Location Column is not tracked since that would require Elixir to pass `column` meta into `Macro.Env`.
* Option End Of Expression is not tracked since the value is expanded and the macro receives the value and not an AST.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
