### PR TITLE
Add DSL entity validation and transformation

### DIFF
--- a/lib/spark/dsl/entity.ex
+++ b/lib/spark/dsl/entity.ex
@@ -249,20 +249,22 @@ defmodule Spark.Dsl.Entity do
 
   @doc false
   def build(
-        %{
-          target: target,
-          schema: schema,
-          auto_set_fields: auto_set_fields,
-          transform: transform,
-          identifier: identifier,
-          singleton_entity_keys: singleton_entity_keys,
-          entities: nested_entity_definitions
-        },
+        entity,
         opts,
         nested_entities,
         anno,
         opts_anno
       ) do
+    %{
+      target: target,
+      schema: schema,
+      auto_set_fields: auto_set_fields,
+      transform: transform,
+      identifier: identifier,
+      singleton_entity_keys: singleton_entity_keys,
+      entities: nested_entity_definitions
+    } = validate_and_transform(entity, [], nil)
+
     with {:ok, opts, more_nested_entities} <-
            fetch_single_argument_entities_from_opts(
              opts,
@@ -455,5 +457,57 @@ defmodule Spark.Dsl.Entity do
     )
 
     nil
+  end
+
+  @doc """
+  Validates and transforms an entity structure, ensuring nested entities are properly formatted.
+
+  This function recursively processes a DSL entity and its nested entities, converting
+  single entity values to lists where needed and validating the structure.
+
+  ## Parameters
+
+  - `entity` - The entity to validate and transform
+  - `path` - The current path in the DSL structure (for error reporting)
+  - `module` - The module context (for error reporting)
+
+  ## Returns
+
+  Returns the transformed entity with normalized nested entity structures.
+  """
+  def validate_and_transform(entity, path \\ [], module \\ nil)
+
+  def validate_and_transform(%Spark.Dsl.Entity{} = entity, path, module) do
+    # Include the entity's name in the path when processing nested entities
+    nested_path = if entity.name, do: path ++ [entity.name], else: path
+
+    entities =
+      entity.entities
+      |> List.wrap()
+      |> Enum.map(fn
+        {key, %Spark.Dsl.Entity{} = value} ->
+          {key, [validate_and_transform(value, nested_path ++ [key], module)]}
+
+        {key, values} when is_list(values) ->
+          # Already a list, keep as is
+          {key, Enum.map(values, &validate_and_transform(&1, nested_path ++ [key], module))}
+
+        {key, value} ->
+          # Non-entity, non-list value - this is invalid
+          raise Spark.Error.DslError,
+            module: module,
+            path: nested_path ++ [key],
+            message:
+              "nested entity '#{key}' must be an entity or list of entities, got: #{inspect(value)}"
+      end)
+
+    %{entity | entities: entities}
+  end
+
+  def validate_and_transform(_, path, module) do
+    raise Spark.Error.DslError,
+      module: module,
+      path: path,
+      message: "Invalid entity structure"
   end
 end

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -829,6 +829,20 @@ defmodule Spark.Dsl.Extension do
     |> Enum.uniq()
   end
 
+  defp validate_and_transform_dsl_patch(
+         %Spark.Dsl.Patch.AddEntity{entity: entity} = dsl_patch,
+         module
+       ) do
+    entity = Spark.Dsl.Entity.validate_and_transform(entity, [], module)
+    %{dsl_patch | entity: entity}
+  end
+
+  defp validate_and_transform_dsl_patch(dsl_patch, _module), do: dsl_patch
+
+  def validate_and_transform_dsl_patches(dsl_patches, module \\ nil) do
+    Enum.map(dsl_patches, &validate_and_transform_dsl_patch(&1, module))
+  end
+
   @doc false
   defmacro build(extension, module_prefix, sections, dsl_patches) do
     quote generated: true,
@@ -839,6 +853,8 @@ defmodule Spark.Dsl.Extension do
             module_prefix: module_prefix
           ] do
       alias Spark.Dsl.Extension
+
+      dsl_patches = Extension.validate_and_transform_dsl_patches(dsl_patches, __MODULE__)
 
       {:ok, agent} = Agent.start_link(fn -> [] end)
       agent_and_pid = {agent, self()}
@@ -880,6 +896,18 @@ defmodule Spark.Dsl.Extension do
   end
 
   @doc false
+  def validate_and_transform_section(
+        %Spark.Dsl.Section{entities: entities} = section,
+        module \\ nil
+      ) do
+    %{
+      section
+      | entities:
+          Enum.map(entities, &Spark.Dsl.Entity.validate_and_transform(&1, [section.name], module))
+    }
+  end
+
+  @doc false
   defmacro build_section(
              agent,
              extension,
@@ -896,6 +924,8 @@ defmodule Spark.Dsl.Extension do
           ],
           generated: true do
       alias Spark.Dsl
+
+      section = Dsl.Extension.validate_and_transform_section(section, __MODULE__)
 
       {section_modules, entity_modules, opts_module} =
         Dsl.Extension.do_build_section(
@@ -1203,7 +1233,6 @@ defmodule Spark.Dsl.Extension do
       Enum.reduce(entity.entities, [], fn
         {key, entities}, nested_entity_mods ->
           entities
-          |> List.wrap()
           |> Enum.reduce(
             nested_entity_mods,
             fn nested_entity, nested_entity_mods ->

--- a/test/dsl_validation_test.exs
+++ b/test/dsl_validation_test.exs
@@ -1,0 +1,88 @@
+defmodule Spark.DslValidationTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  describe "invalid DSL definitions" do
+    test "entity nested definitions cannot be atoms" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule InvalidNestedEntities do
+            @moduledoc false
+
+            defmodule Dsl do
+              @moduledoc false
+
+              @child %Spark.Dsl.Entity{
+                name: :child,
+                target: Spark.Test.Step,
+                schema: []
+              }
+
+              @parent %Spark.Dsl.Entity{
+                name: :parent,
+                target: Spark.Test.Step,
+                schema: [],
+                # Invalid - should be an entity, not an atom
+                entities: [child: :child_entity]
+              }
+
+              @section %Spark.Dsl.Section{
+                name: :root,
+                entities: [@parent]
+              }
+
+              use Spark.Dsl.Extension, sections: [@section]
+            end
+
+            use Spark.Dsl, default_extensions: [extensions: Dsl]
+          end
+        end
+
+      assert error.message =~
+               "nested entity 'child' must be an entity or list of entities, got: :child_entity"
+
+      assert error.path == [:root, :parent, :child]
+      assert error.module == Spark.DslValidationTest.InvalidNestedEntities.Dsl
+    end
+
+    test "entity nested definitions must be lists of entities or a single entity" do
+      defmodule ValidNestedEntities do
+        @moduledoc false
+
+        defmodule Dsl do
+          @moduledoc false
+
+          @child %Spark.Dsl.Entity{
+            name: :child,
+            target: Spark.Test.Step,
+            schema: []
+          }
+
+          @different_child %Spark.Dsl.Entity{
+            name: :different_child,
+            target: Spark.Test.Step,
+            schema: []
+          }
+
+          @parent %Spark.Dsl.Entity{
+            name: :parent,
+            target: Spark.Test.Step,
+            schema: [],
+            # Both formats are valid
+            entities: [child: @child, other_children: [@different_child]]
+          }
+
+          @section %Spark.Dsl.Section{
+            name: :root,
+            entities: [@parent]
+          }
+
+          use Spark.Dsl.Extension, sections: [@section]
+        end
+
+        use Spark.Dsl, default_extensions: [extensions: Dsl]
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Overview
Fixes #215 

Instead of adding an additional `List.wrap`, I thought it might be a good idea to perform validation and transformation early on. This PR removes one List.wrap :P

I believe this might cause a slow down of consumers, as we potentially recurse the entity tree repeatedly and don't cache the transformation results.

As a demo, this implements #215. But more validations could be added to catch common misconfigurations. (E.g. to also allow sub-entities without keys, by transforming `entities: [@child]` to `entities: [child_entity_name: [@child]]`.

Please let me know if this is feasible/wanted - otherwise I'll just add the List.wrap :)

# LLM generated commit message

Implements early validation of DSL entity structures to catch configuration errors at compile time rather than runtime. Key improvements:

- Add validate_and_transform/3 function for recursive entity validation
- Ensure nested entities are properly formatted as lists
- Add validation hooks in extension building, section processing, and patches
- Provide detailed error messages with module and path context
- Add test coverage for validation scenarios

This prevents invalid DSL configurations from causing runtime errors and provides better developer experience with clear error messages.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
