### PR TITLE
fix: hoist validation and transformation to top of call chain

### DIFF
--- a/test/dsl_validation_test.exs
+++ b/test/dsl_validation_test.exs
@@ -84,5 +84,47 @@ defmodule Spark.DslValidationTest do
         use Spark.Dsl, default_extensions: [extensions: Dsl]
       end
     end
+
+    test "dsl patches with nested entity definitions are properly transformed" do
+      defmodule DslPatchWithNestedEntities do
+        @moduledoc false
+
+        defmodule PatcherExtension do
+          @moduledoc false
+
+          @nested_entity %Spark.Dsl.Entity{
+            name: :nested_item,
+            target: Spark.Test.Step,
+            schema: []
+          }
+
+          @another_nested %Spark.Dsl.Entity{
+            name: :another_nested_item,
+            target: Spark.Test.Step,
+            schema: []
+          }
+
+          @patched_entity %Spark.Dsl.Entity{
+            name: :patched_entity,
+            target: Spark.Test.Step,
+            schema: [],
+            # Test both single entity and list formats in nested entities
+            entities: [
+              single: @nested_entity,
+              multiple: [@another_nested]
+            ]
+          }
+
+          @patch %Spark.Dsl.Patch.AddEntity{
+            section_path: [:steps],
+            entity: @patched_entity
+          }
+
+          use Spark.Dsl.Extension, dsl_patches: [@patch]
+        end
+
+        use Spark.Dsl, default_extensions: [extensions: [Spark.Test.Extension, PatcherExtension]]
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes the failing validation test (https://github.com/ash-project/spark/actions/runs/18011100579/job/51243787914). Before, set_docs would be called on the un-transformed sections.

The `validate_and_transform_*` functions are now all in `extension.ex`. 

This should be cleaner now. I'm not sure if moving `set_docs` into the`extension` module is a problem.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
