### PR TITLE
Only store source location if :debug_info enabled

### DIFF
--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -2170,9 +2170,11 @@ defmodule Spark.Dsl.Extension do
 
   @spec macro_env_anno(env :: Macro.Env.t(), do_block :: Macro.t()) :: :erl_anno.anno()
   def macro_env_anno(env, do_block) do
-    anno = :erl_anno.new(env.line)
-    anno = :erl_anno.set_file(String.to_charlist(env.file), anno)
-    maybe_set_end_location(anno, do_block)
+    if Code.compiler_options()[:debug_info] do
+      anno = :erl_anno.new(env.line)
+      anno = :erl_anno.set_file(String.to_charlist(env.file), anno)
+      maybe_set_end_location(anno, do_block)
+    end
   end
 
   @spec maybe_set_end_location(:erl_anno.anno(), Macro.t() | nil) :: :erl_anno.anno()


### PR DESCRIPTION
# What?

Only store source locations if the `debug_info` compiler option is enabled.

Reasons:
* Paths make no sense in mix releases since files won't be in the same location
* Builds are no longer reproducible

# Impact on Tests

`debug_info` is not enabled for mix test cases. If a user has a `defmodule` inside a test, `debug_info` needs to be enabled. This should be mentioned in the changelog.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
