### PR TITLE
docs: improve documentation for Transformers, Persisters, and Verifiers

### DIFF
--- a/documentation/how_to/writing-extensions.md
+++ b/documentation/how_to/writing-extensions.md
@@ -23,7 +23,7 @@ The overall execution order is:
 
 1. **Transformers** — run during compilation, in dependency order. Can read and modify any part of the DSL state.
 2. **Persisters** — run during compilation, after all Transformers have completed. Should only write to the persisted data map.
-3. **Verifiers** — run after the module is compiled. Read-only. Do not create compile-time dependencies between modules.
+3. **Verifiers** — run after the module is compiled. Read-only. Does not create compile-time dependencies between modules.
 
 All three are declared as options to `use Spark.Dsl.Extension`:
 

--- a/documentation/how_to/writing-extensions.md
+++ b/documentation/how_to/writing-extensions.md
@@ -15,9 +15,104 @@ The DSL is declared as a series of `Spark.Dsl.Section`, which can contain `Spark
 
 If you want to build those structs programmatically, see [Building Extensions with the Builder API](build-extensions-with-builders.md).
 
+## Compile-time processing: Transformers, Persisters, and Verifiers
+
+Extensions can hook into compilation at two stages: during compilation (Transformers and Persisters) and after compilation (Verifiers). Within the compilation stage, all Transformers run before any Persisters.
+
+The overall execution order is:
+
+1. **Transformers** — run during compilation, in dependency order. Can read and modify any part of the DSL state.
+2. **Persisters** — run during compilation, after all Transformers have completed. Should only write to the persisted data map.
+3. **Verifiers** — run after the module is compiled. Read-only. Do not create compile-time dependencies between modules.
+
+All three are declared as options to `use Spark.Dsl.Extension`:
+
+```elixir
+use Spark.Dsl.Extension,
+  sections: [@my_section],
+  transformers: [MyApp.Transformers.SetDefaults],
+  persisters: [MyApp.Persisters.CacheComputedValues],
+  verifiers: [MyApp.Verifiers.ValidateConfig]
+```
+
 ## Transformers
 
-Extension writing gets a bit more complicated when you get into the world of transformers, but this is also where a lot of the power is. Each transformer can declare other transformers it must go before or after, and then is given the opportunity to modify the entirety of the DSL it is extending up to that point. This allows extensions to make rich modifications to the structure in question. See `Spark.Dsl.Transformer` for more information
+Each transformer can declare other transformers it must go before or after using `before?/1` and `after?/1` callbacks, and is then given the opportunity to modify the entirety of the DSL state. This allows extensions to make rich modifications to the structure in question.
+
+```elixir
+defmodule MyApp.Transformers.SetDefaults do
+  use Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    name = Spark.Dsl.Transformer.get_option(dsl_state, [:my_section], :name)
+    dsl_state = Spark.Dsl.Transformer.persist(dsl_state, :name, name || :default)
+    {:ok, dsl_state}
+  end
+
+  def after?(MyApp.Transformers.EarlierTransformer), do: true
+  def after?(_), do: false
+end
+```
+
+See `Spark.Dsl.Transformer` for the full list of helper functions and return values.
+
+## Persisters
+
+Persisters implement the same `Spark.Dsl.Transformer` behaviour as transformers — they use `use Spark.Dsl.Transformer` and define a `transform/1` callback. The differences are:
+
+- They are listed under `persisters:` instead of `transformers:`
+- They **always** run after all transformers have finished, regardless of any `before?`/`after?` declarations targeting transformers (those are silently ignored)
+- By convention, they should **only** write to the persisted data map via `Spark.Dsl.Transformer.persist/3`, and should not mutate sections or entities
+
+Persisters do support `before?`/`after?` ordering relative to **other persisters**.
+
+Use persisters to precompute and cache derived values that need a complete, fully-transformed view of the DSL:
+
+```elixir
+defmodule MyApp.Persisters.CacheActionNames do
+  use Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    action_names =
+      dsl_state
+      |> Spark.Dsl.Transformer.get_entities([:actions])
+      |> Enum.map(& &1.name)
+
+    {:ok, Spark.Dsl.Transformer.persist(dsl_state, :action_names, action_names)}
+  end
+end
+```
+
+Persisted values can be retrieved at runtime via `Spark.Dsl.Extension.get_persisted/3`.
+
+## Verifiers
+
+Verifiers validate DSL state after the module has been compiled. They are read-only — they cannot modify the DSL state, only return `:ok`, `{:error, term}`, or `{:warn, warning}`. Because verifiers run post-compilation, they can safely reference other modules without creating compile-time dependencies between them.
+
+```elixir
+defmodule MyApp.Verifiers.ValidateConfig do
+  use Spark.Dsl.Verifier
+
+  def verify(dsl_state) do
+    name = Spark.Dsl.Verifier.get_option(dsl_state, [:my_section], :name)
+
+    if name do
+      :ok
+    else
+      {:error,
+       Spark.Error.DslError.exception(
+         message: "name is required",
+         path: [:my_section, :name],
+         module: Spark.Dsl.Verifier.get_persisted(dsl_state, :module)
+       )}
+    end
+  end
+end
+```
+
+Prefer verifiers over transformers when you only need to validate — they run later, see the final state, and their post-compilation timing avoids circular compile-time dependencies when referencing other Spark-based modules.
+
+See `Spark.Dsl.Verifier` for the full list of helper functions and return values.
 
 ## Introspection
 

--- a/documentation/tutorials/get-started-with-spark.md
+++ b/documentation/tutorials/get-started-with-spark.md
@@ -264,12 +264,64 @@ iex(1)> MyLibrary.Validator.Info.fields(MyApp.PersonValidator)
 ]
 ```
 
+### Persisters
+
+Persisters are a special kind of transformer used to precompute and cache values onto the DSL.
+They implement the same `Spark.Dsl.Transformer` behaviour, but are listed under `persisters:`
+instead of `transformers:`. The key differences are:
+
+- Persisters **always** run after all transformers have finished — they see the complete,
+  fully-transformed DSL state. A persister cannot run before a transformer, even if it declares
+  `before?(SomeTransformer)` — that declaration is silently ignored.
+- By convention, persisters should **only** write to the persisted data map (via
+  `Spark.Dsl.Transformer.persist/3`) and should not add, remove, or modify sections or entities.
+- Persisters support `before?`/`after?` ordering relative to other persisters.
+
+A typical use case is caching a derived value so it can be read quickly at runtime without
+re-traversing the DSL:
+
+```elixir
+defmodule MyLibrary.Validator.Persisters.CacheFieldNames do
+  use Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    field_names =
+      dsl_state
+      |> Spark.Dsl.Transformer.get_entities([:fields])
+      |> Enum.map(& &1.name)
+
+    {:ok, Spark.Dsl.Transformer.persist(dsl_state, :field_names, field_names)}
+  end
+end
+```
+
+```elixir
+use Spark.Dsl.Extension,
+  sections: [@fields],
+  transformers: [
+    MyLibrary.Validator.Transformers.AddId,
+    MyLibrary.Validator.Transformers.GenerateValidate
+  ],
+  persisters: [
+    MyLibrary.Validator.Persisters.CacheFieldNames
+  ],
+  verifiers: [
+    MyLibrary.Validator.Verifiers.VerifyRequired
+  ]
+```
+
 ### Verifiers
 
-Verifiers are similar to transformers, except that they *cannot modify the structure*. They can
-only return `:ok` or `{:error, error}`. This is important because when verifiers are running
-you know that you are looking at the *final* structure of the DSL. Prefer to write verifiers
-over transformers if you are only doing some kind of validation.
+Verifiers validate DSL state, but unlike transformers and persisters, they run **after** the
+module has been compiled. They are read-only — they can only return `:ok`, `{:error, error}`,
+or `{:warn, warning}`, and cannot modify the DSL state.
+
+Because verifiers run post-compilation, they can safely reference other modules without creating
+compile-time dependencies between them. This is important when building extensions that need to
+cross-check multiple Spark-based modules (e.g. verifying that a referenced resource exists).
+
+Prefer verifiers over transformers when you are only doing validation — they see the final,
+fully-transformed DSL state and avoid circular compile-time dependencies.
 
 Lets make a verifier that says that all fields in `required` must also be in `fields`.
 
@@ -386,6 +438,9 @@ use Spark.Dsl.Extension,
   transformers: [
     MyLibrary.Validator.Transformers.AddId,
     MyLibrary.Validator.Transformers.GenerateValidate
+  ],
+  persisters: [
+    MyLibrary.Validator.Persisters.CacheFieldNames
   ],
   verifiers: [
     MyLibrary.Validator.Verifiers.VerifyRequired

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -87,13 +87,29 @@ defmodule Spark.Dsl.Extension do
   Often, we will need to do complex validation/validate based on the configuration
   of other resources. Due to the nature of building compile time DSLs, there are
   many restrictions around that process. To support these complex use cases, extensions
-  can include `transformers` which can validate/transform the DSL state after all basic
-  sections/entities have been created. See `Spark.Dsl.Transformer` for more information.
-  Transformers are provided as an option to `use`, like so:
+  can include `transformers`, `persisters`, and `verifiers`. These run in the following
+  order:
 
-      use Spark.Dsl.Extension, sections: [@cars], transformers: [
-        MyApp.Transformers.ValidateNoOverlappingMakesAndModels
-      ]
+  1. **Transformers** — run during compilation, in dependency order (controlled by `before?/1`
+     and `after?/1`). Can read and modify any part of the DSL state. See `Spark.Dsl.Transformer`.
+
+  2. **Persisters** — run during compilation, always after all transformers. They implement the
+     same `Spark.Dsl.Transformer` behaviour but are declared under `persisters:`. By convention
+     they should only write to the persisted data map via `Spark.Dsl.Transformer.persist/3`.
+     They support `before?`/`after?` ordering relative to other persisters, but any ordering
+     declarations targeting transformers are silently ignored.
+
+  3. **Verifiers** — run after the module is compiled. Read-only. Do not create compile-time
+     dependencies between modules, so they are safe to use when referencing other Spark-based
+     modules. See `Spark.Dsl.Verifier`.
+
+  All three are provided as options to `use`:
+
+      use Spark.Dsl.Extension,
+        sections: [@cars],
+        transformers: [MyApp.Transformers.ValidateNoOverlappingMakesAndModels],
+        persisters: [MyApp.Persisters.CacheCarCount],
+        verifiers: [MyApp.Verifiers.CheckManufacturerExists]
 
   By default, the generated modules will have names like `__MODULE__.SectionName.EntityName`, and that could
   potentially conflict with modules you are defining, so you can specify the `module_prefix` option, which would allow

--- a/lib/spark/dsl/transformer.ex
+++ b/lib/spark/dsl/transformer.ex
@@ -42,11 +42,17 @@ defmodule Spark.Dsl.Transformer do
   For reading: `get_entities/2`, `get_option/3`, `fetch_option/3`, `get_persisted/2`.
   For writing: `add_entity/3`, `replace_entity/3`, `remove_entity/3`, `set_option/4`, `persist/3`.
 
-  ## Transformers vs. Verifiers
+  ## Transformers vs. Persisters vs. Verifiers
 
-  If you only need to validate state without modifying it, and you reference other modules
-  (e.g. checking that a referenced module exists), use `Spark.Dsl.Verifier` instead.
-  Verifiers run after compilation and do not create compile-time dependencies between modules.
+  **Persisters** also use this behaviour (`use Spark.Dsl.Transformer`) but are declared under
+  `persisters:` in the extension rather than `transformers:`. They always run after all
+  transformers have completed, regardless of any `before?`/`after?` declarations targeting
+  transformer modules. By convention, persisters should only write to the persisted data map
+  via `persist/3` and should not mutate sections or entities. They support `before?`/`after?`
+  ordering relative to other persisters. See `Spark.Dsl.Extension` for more.
+
+  **Verifiers** (`Spark.Dsl.Verifier`) are for validation only — they run after compilation,
+  cannot modify DSL state, and do not create compile-time dependencies between modules.
   """
 
   @type warning() :: String.t() | {String.t(), :erl_anno.anno()}


### PR DESCRIPTION
- Expand writing-extensions.md with dedicated sections for each type, code examples, and an execution order overview
- Add a Persisters section to the getting started tutorial; fix the Verifiers description to cover post-compilation timing, read-only constraint, and the compile-dependency benefit
- Update Spark.Dsl.Transformer moduledoc to describe the relationship between transformers, persisters, and verifiers
- Update Spark.Dsl.Extension moduledoc with a numbered execution order and usage example covering all three types

Key clarification included: persisters support before?/after? ordering relative to other persisters, but any declarations targeting transformer modules are silently ignored — persisters always run after all transformers.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [*] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [*] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
