### PR TITLE
feat: add Spark.Test for testing verifier errors and warnings as data

### DIFF
--- a/documentation/how_to/test-spark-verifiers.md
+++ b/documentation/how_to/test-spark-verifiers.md
@@ -1,0 +1,219 @@
+<!--
+SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs.contributors>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Testing Spark Verifiers
+
+Verifier errors raised inside Spark's `@after_verify` hook are caught by the
+framework and emitted as stderr warnings instead of propagated as exceptions.
+This keeps compilation flowing when a DSL is invalid, but it means the
+natural ExUnit pattern — `assert_raise/2` — does not work.
+
+`Spark.Test` provides ExUnit helpers that turn the captured errors and
+warnings back into structured data your tests can pattern-match on.
+
+## Quick reference
+
+| Intent | Errors | Warnings |
+|---|---|---|
+| Collect everything as a list | `dsl_errors/1` | `dsl_warnings/1` |
+| Assert at least one matches a pattern | `assert_dsl_error/2` (or `/1` for any) | `assert_dsl_warning/2` (or `/1` for any) |
+| Assert nothing was produced | `refute_dsl_errors/1` | `refute_dsl_warnings/1` |
+
+`import Spark.Test` makes all six available.
+
+## Defining modules inside the helpers
+
+This rule catches everyone. Inside the macro's anonymous-function body, a
+bare alias like `BadPerson` resolves against the surrounding test module's
+scope. Outside — where your `assert` patterns live — the same alias
+resolves at the top level. They become different atoms, and your patterns
+will never match.
+
+Force top-level resolution with the explicit `Elixir.X` form:
+
+```elixir
+errors =
+  dsl_errors do
+    defmodule Elixir.BadPerson do  # <-- note the Elixir. prefix
+      ...
+    end
+  end
+
+assert [{BadPerson, _}] = errors    # <-- bare alias resolves to Elixir.BadPerson, matches
+```
+
+Always use the `Elixir.X` form for any module you intend to assert on.
+
+## Testing a verifier that produces errors
+
+Anything that returns `{:error, %Spark.Error.DslError{}}` from
+`Spark.Dsl.Verifier.verify/1` — your own verifiers and Spark's built-ins
+(`VerifyEntityUniqueness`, `VerifySectionSingletonEntities`).
+
+### Match a specific error
+
+`assert_dsl_error/2` is the most common shape. It takes a pattern, runs the
+do-block, and returns the first matching error so you can do follow-up
+assertions on it:
+
+```elixir
+defmodule MyApp.PersonValidatorTest do
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  test "rejects an invalid email" do
+    err =
+      assert_dsl_error %Spark.Error.DslError{path: [:fields, :email]} do
+        defmodule Elixir.BadPerson do
+          use MyApp.PersonValidator
+
+          fields do
+            field :email, :string do
+              check &String.contains?(&1, "@")
+            end
+          end
+        end
+      end
+
+    assert err.message =~ "invalid email"
+  end
+end
+```
+
+The pattern is matched via `match?/2`, so any valid Elixir pattern works.
+On no match the test fails with a message that includes the pattern source
+and the inspected list of actual errors.
+
+When the pattern doesn't matter, use the `/1` form:
+
+```elixir
+err =
+  assert_dsl_error do
+    defmodule Elixir.BadPerson do
+      # ...
+    end
+  end
+```
+
+### Assert clean compilation
+
+For happy-path tests where no error should be produced:
+
+```elixir
+test "valid configuration is accepted" do
+  refute_dsl_errors do
+    defmodule Elixir.GoodPerson do
+      use MyApp.PersonValidator
+
+      fields do
+        field :email, :string
+      end
+    end
+  end
+end
+```
+
+Returns `:ok` on success. On failure the message lists the offending
+modules and their errors.
+
+### Work with the full collected list
+
+Use `dsl_errors/1` directly when you need to compare error counts, assert
+on multiple distinct errors at once, or otherwise inspect the full result.
+The shape is `[{module, [%Spark.Error.DslError{}]}, ...]` in definition
+order:
+
+```elixir
+errors =
+  dsl_errors do
+    defmodule Elixir.HasTwoIssues do
+      # ...
+    end
+  end
+
+assert [{HasTwoIssues, errors_list}] = errors
+assert length(errors_list) == 2
+```
+
+## Testing a verifier that produces warnings
+
+The same three helpers exist (`dsl_warnings/1`, `assert_dsl_warning/2,/1`,
+`refute_dsl_warnings/1`) with one shape difference:
+
+**Warnings are normalized to `{message, location | nil}` tuples**, not
+`Spark.Error.DslError` structs. A bare-string warning `{:warn, "msg"}`
+becomes `{"msg", nil}`; a tuple-form warning `{:warn, {"msg", anno}}`
+preserves the location.
+
+```elixir
+test "deprecated option emits a warning" do
+  {message, _location} =
+    assert_dsl_warning {_, _} do
+      defmodule Elixir.UsesDeprecatedOption do
+        use MyApp.Validator
+
+        fields do
+          field :legacy_option, :string
+        end
+      end
+    end
+
+  assert message =~ "deprecated"
+end
+```
+
+For literal-message matching put the string in the pattern:
+
+```elixir
+{_, _} =
+  assert_dsl_warning {"legacy_option is deprecated", _} do
+    # ...
+  end
+```
+
+`refute_dsl_warnings/1` and `dsl_warnings/1` work identically to their
+errors counterparts, just with the warning payload shape.
+
+## What the helpers don't capture
+
+- **`Spark.Warning.warn/3` called directly** — for example by
+  `Spark.Options` for schema-level deprecation warnings, or by
+  `Spark.Dsl.Extension.__after_verify__/1` for `__spark_metadata__`
+  deprecation. These bypass the verifier-callback path. Use
+  `capture_io(:stderr, ...)` to assert on them.
+- **Transformer warnings** — `{:warn, dsl_state, warnings}` returns from
+  `Spark.Dsl.Transformer.transform/1` flow through a separate code path
+  and are not collected.
+
+## Async safety
+
+The helpers are safe in `async: true` ExUnit tests. The collection
+mechanism uses per-process state (`Process.put/2`) and point-to-point
+`send/2`; nothing crosses process boundaries.
+
+One caveat: any `defmodule` defined inside a process you spawn yourself
+won't be captured, because the spawned process has its own dictionary.
+Either keep `defmodule` calls in the same process as the helper, or set
+the collector flag explicitly inside the spawned process:
+
+```elixir
+parent = self()
+
+Task.async(fn ->
+  Process.put({Spark.Dsl, :test_collector}, parent)
+  defmodule Elixir.SomeModule do
+    # ...
+  end
+end)
+|> Task.await()
+```
+
+## See also
+
+- `Spark.Test` — the helper module
+- `Spark.Dsl.Verifier` — the verifier callback contract
+- `Spark.Error.DslError` — the error struct returned by the error helpers

--- a/lib/spark/dsl.ex
+++ b/lib/spark/dsl.ex
@@ -483,15 +483,26 @@ defmodule Spark.Dsl do
                     []
 
                   {:warn, warnings} ->
-                    warnings
-                    |> List.wrap()
-                    |> Enum.each(fn
-                      {warning, location} ->
-                        Spark.Warning.warn(warning, location, Macro.Env.stacktrace(__ENV__))
+                    collector = Process.get({Spark.Dsl, :test_collector})
 
-                      warning ->
-                        Spark.Warning.warn(warning, nil, Macro.Env.stacktrace(__ENV__))
-                    end)
+                    normalized =
+                      warnings
+                      |> List.wrap()
+                      |> Enum.map(fn
+                        {msg, loc} -> {msg, loc}
+                        msg -> {msg, nil}
+                      end)
+
+                    if is_pid(collector) do
+                      send(
+                        collector,
+                        {Spark.Dsl, :verifier_warnings, __MODULE__, normalized}
+                      )
+                    else
+                      Enum.each(normalized, fn {msg, loc} ->
+                        Spark.Warning.warn(msg, loc, Macro.Env.stacktrace(__ENV__))
+                      end)
+                    end
 
                     []
 
@@ -504,38 +515,46 @@ defmodule Spark.Dsl do
               end
             end)
 
-          case Enum.uniq(errors) do
-            [] ->
+          final_errors = Enum.uniq(errors)
+          collector = Process.get({Spark.Dsl, :test_collector})
+
+          cond do
+            final_errors == [] ->
+              __MODULE__
+              |> Spark.Dsl.Extension.run_transformers(
+                transformers_to_run,
+                @spark_dsl_config,
+                __ENV__
+              )
+
+            is_pid(collector) ->
+              send(collector, {Spark.Dsl, :verifier_errors, __MODULE__, final_errors})
               :ok
 
-            [%Spark.Error.DslError{stacktrace: %{stacktrace: stacktrace}} = error] ->
-              reraise error, stacktrace
+            true ->
+              case final_errors do
+                [%Spark.Error.DslError{stacktrace: %{stacktrace: stacktrace}} = error] ->
+                  reraise error, stacktrace
 
-            [error] ->
-              raise error
+                [error] ->
+                  raise error
 
-            errors ->
-              raise Spark.Error.DslError,
-                message:
-                  "Multiple Errors Occurred\n\n" <>
-                    Enum.map_join(errors, "\n---\n", fn
-                      %Spark.Error.DslError{stacktrace: %{stacktrace: stacktrace}} = error ->
-                        Exception.format(:error, error, stacktrace)
+                errors ->
+                  raise Spark.Error.DslError,
+                    message:
+                      "Multiple Errors Occurred\n\n" <>
+                        Enum.map_join(errors, "\n---\n", fn
+                          %Spark.Error.DslError{stacktrace: %{stacktrace: stacktrace}} = error ->
+                            Exception.format(:error, error, stacktrace)
 
-                      error ->
-                        {:current_stacktrace, stacktrace} =
-                          Process.info(self(), :current_stacktrace)
+                          error ->
+                            {:current_stacktrace, stacktrace} =
+                              Process.info(self(), :current_stacktrace)
 
-                        Exception.format(:error, error, stacktrace)
-                    end)
+                            Exception.format(:error, error, stacktrace)
+                        end)
+              end
           end
-
-          __MODULE__
-          |> Spark.Dsl.Extension.run_transformers(
-            transformers_to_run,
-            @spark_dsl_config,
-            __ENV__
-          )
         catch
           kind, %Spark.Error.DslError{location: location} = reason ->
             Spark.Warning.warn(

--- a/lib/spark/dsl/verifier.ex
+++ b/lib/spark/dsl/verifier.ex
@@ -35,6 +35,18 @@ defmodule Spark.Dsl.Verifier do
 
   This module delegates read-only functions from `Spark.Dsl.Transformer`:
   `get_entities/2`, `get_option/3`, `fetch_option/3`, `get_persisted/2`.
+
+  ## Testing
+
+  See `Spark.Test` for ExUnit helpers that turn verifier errors and
+  warnings into structured data instead of stderr output, so tests can
+  pattern-match on them:
+
+  - `Spark.Test.dsl_errors/1`, `Spark.Test.assert_dsl_error/2`,
+    `Spark.Test.refute_dsl_errors/1` for `{:error, _}` returns and raised
+    `Spark.Error.DslError` values.
+  - `Spark.Test.dsl_warnings/1`, `Spark.Test.assert_dsl_warning/2`,
+    `Spark.Test.refute_dsl_warnings/1` for `{:warn, _}` returns.
   """
 
   @type warning() :: String.t() | {String.t(), :erl_anno.anno()}

--- a/lib/spark/test.ex
+++ b/lib/spark/test.ex
@@ -1,0 +1,406 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test do
+  @moduledoc """
+  ExUnit helpers for testing Spark DSL verifiers.
+
+  Verifier errors raised inside Spark's `@after_verify` hook are converted to
+  stderr warnings by the framework rather than propagated as exceptions, so
+  the usual `assert_raise/2` testing pattern is unsuitable. This module
+  exposes a structured alternative: register the test process as a collector,
+  define DSL modules, and receive their `Spark.Error.DslError` values as data.
+
+  ## Helpers
+
+  - `dsl_errors/1` — runs a do-block and returns all collected verifier errors
+    as `[{module, [%Spark.Error.DslError{}]}, ...]`. The error-side primitive.
+  - `dsl_warnings/1` — runs a do-block and returns all collected verifier
+    warnings as `[{module, [{message, location | nil}, ...]}, ...]`. The
+    warning-side primitive.
+  - `assert_dsl_error/2` — asserts that the do-block produces at least one
+    error matching a given pattern and returns the matched error.
+  - `assert_dsl_error/1` — like `/2` with a wildcard pattern: asserts at
+    least one error of any kind.
+  - `assert_dsl_warning/2` — asserts that the do-block produces at least
+    one warning matching a given pattern and returns the matched payload.
+  - `assert_dsl_warning/1` — like `/2` with a wildcard pattern: asserts at
+    least one warning of any kind.
+  - `refute_dsl_errors/1` — asserts that the do-block produces no errors at
+    all. Use for happy-path tests.
+  - `refute_dsl_warnings/1` — asserts that the do-block produces no
+    warnings at all.
+
+  ## Examples
+
+      iex> Spark.Test.dsl_errors(do: :ok)
+      []
+
+      iex> Spark.Test.dsl_warnings(do: :ok)
+      []
+
+  See `dsl_errors/1`, `dsl_warnings/1`, `assert_dsl_error/2`, and
+  `refute_dsl_errors/1` for full usage.
+
+  ## Async safety
+
+  All helpers in this module are safe to use from `async: true` ExUnit tests.
+  The collection mechanism uses per-process state (`Process.put/2` and
+  point-to-point `send/2`) and does not cross process boundaries.
+  """
+
+  @doc """
+  Collects verifier errors from any Spark DSL modules defined inside the
+  given do-block.
+
+  Returns a list of `{module, [%Spark.Error.DslError{}]}` tuples in
+  definition order. Modules that compile cleanly produce no entry. Stderr
+  output emitted by verifiers (notably `{:warn, _}` returns) is suppressed
+  during the call.
+
+  ## Examples
+
+  No DSL modules → empty list:
+
+      errors = dsl_errors do
+        :ok
+      end
+      # => []
+
+  A failing DSL module → its errors:
+
+      errors = dsl_errors do
+        defmodule Elixir.MyExample do
+          use MyApp.Validator
+
+          fields do
+            # invalid configuration here
+          end
+        end
+      end
+
+      [{MyExample, [%Spark.Error.DslError{} | _]}] = errors
+
+  ## Module names defined inside the do-block
+
+  Modules whose errors you intend to assert on must be defined with the
+  fully-qualified `Elixir.SomeName` form. A bare alias inside the macro's
+  callback is resolved against the surrounding test module's scope, while
+  the same alias outside the call is resolved at the top level — without
+  the `Elixir.` prefix the two atoms would not match.
+
+  ## Cleanup
+
+  The collector flag is restored to its prior value (or unset if there was
+  no prior value) when the call returns or when the block raises. Stale
+  messages are drained from the test process's mailbox so subsequent calls
+  are not contaminated.
+
+  See `Spark.Dsl.Verifier` for the verifier callback contract.
+  """
+  defmacro dsl_errors(do: block) do
+    quote do
+      previous = Process.put({Spark.Dsl, :test_collector}, self())
+
+      try do
+        ExUnit.CaptureIO.capture_io(:stderr, fn -> unquote(block) end)
+        Spark.Test.__drain_errors__([])
+      after
+        case previous do
+          nil -> Process.delete({Spark.Dsl, :test_collector})
+          prev -> Process.put({Spark.Dsl, :test_collector}, prev)
+        end
+
+        Spark.Test.__drain_errors__([])
+        Spark.Test.__drain_warnings__([])
+      end
+    end
+  end
+
+  @doc """
+  Collects verifier warnings from any Spark DSL modules defined inside the
+  given do-block.
+
+  Returns a list of `{module, [{message, location | nil}, ...]}` tuples in
+  definition order. Modules that compile cleanly produce no entry. The
+  payloads are normalized: bare-string warnings become `{message, nil}`,
+  tuple-form warnings preserve their `:erl_anno` location.
+
+  Stderr output emitted from the block is suppressed during the call.
+
+  ## Examples
+
+  No DSL modules → empty list:
+
+      warnings = dsl_warnings do
+        :ok
+      end
+      # => []
+
+  A DSL module with a warning verifier → its payloads:
+
+      warnings = dsl_warnings do
+        defmodule Elixir.MyExample do
+          use MyApp.Validator
+          # ... configuration that triggers the warning
+        end
+      end
+
+      [{MyExample, [{message, _location} | _]}] = warnings
+
+  See `dsl_errors/1` for the symmetric error-collection helper, and
+  `Spark.Dsl.Verifier` for the verifier callback contract — including
+  the shape of `{:warn, _}` returns.
+  """
+  defmacro dsl_warnings(do: block) do
+    quote do
+      previous = Process.put({Spark.Dsl, :test_collector}, self())
+
+      try do
+        ExUnit.CaptureIO.capture_io(:stderr, fn -> unquote(block) end)
+        Spark.Test.__drain_warnings__([])
+      after
+        case previous do
+          nil -> Process.delete({Spark.Dsl, :test_collector})
+          prev -> Process.put({Spark.Dsl, :test_collector}, prev)
+        end
+
+        Spark.Test.__drain_errors__([])
+        Spark.Test.__drain_warnings__([])
+      end
+    end
+  end
+
+  @doc """
+  Asserts that the given do-block produces at least one verifier error and
+  returns the first one.
+
+  Equivalent to `assert_dsl_error/2` with a wildcard pattern: any
+  `Spark.Error.DslError` matches. See `assert_dsl_error/2` for details on
+  failure semantics, `refute_dsl_errors/1` for the inverse assertion, and
+  `assert_dsl_warning/1` for the warning-side counterpart.
+  """
+  defmacro assert_dsl_error(do: block) do
+    build_assert_error(quote(do: _), block)
+  end
+
+  @doc """
+  Asserts that the given do-block produces at least one verifier error
+  matching `pattern` and returns the matched error.
+
+  `pattern` is matched against each `Spark.Error.DslError` in definition
+  order via `match?/2`. The first match is returned. If no error matches,
+  the test fails with a message that includes both the source form of the
+  pattern and the inspected list of all collected errors.
+
+  ## Examples
+
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:fields, :email]} do
+          defmodule Elixir.MyExample do
+            use MyApp.Validator
+            # ... configuration that triggers the verifier
+          end
+        end
+
+      assert err.message =~ "invalid email"
+
+  See `dsl_errors/1` for the underlying collection mechanism, including the
+  rules for module names defined inside the do-block.
+  """
+  defmacro assert_dsl_error(pattern, do: block) do
+    build_assert_error(pattern, block)
+  end
+
+  @doc """
+  Asserts that the given do-block produces at least one verifier warning and
+  returns the first one.
+
+  Equivalent to `assert_dsl_warning/2` with a wildcard pattern: any warning
+  payload matches. See `assert_dsl_warning/2` for details on failure
+  semantics, and `assert_dsl_error/1` for the error-side counterpart.
+  """
+  defmacro assert_dsl_warning(do: block) do
+    build_assert_warning(quote(do: _), block)
+  end
+
+  @doc """
+  Asserts that the given do-block produces at least one verifier warning
+  matching `pattern` and returns the matched payload.
+
+  Each warning payload is a `{message, location | nil}` tuple. `pattern` is
+  matched against each payload in definition order via `match?/2`. The first
+  match is returned. If no payload matches, the test fails with a message
+  that includes both the source form of the pattern and the inspected list
+  of all collected warnings.
+
+  ## Examples
+
+      {message, _location} =
+        assert_dsl_warning {_, _} do
+          defmodule Elixir.MyExample do
+            use MyApp.Validator
+            # ... configuration that triggers the warning
+          end
+        end
+
+      assert message =~ "deprecated"
+
+  See `dsl_warnings/1` for the underlying collection mechanism, including
+  the normalization of bare-string warnings to `{message, nil}` tuples.
+  """
+  defmacro assert_dsl_warning(pattern, do: block) do
+    build_assert_warning(pattern, block)
+  end
+
+  @doc """
+  Asserts that the given do-block produces no verifier errors.
+
+  Returns `:ok` on success. If any `Spark.Error.DslError` values are
+  collected, the test fails with a message that includes the inspected
+  `[{module, [errors]}]` list, so the offending modules and their errors
+  are visible in the failure output.
+
+  Use this for happy-path tests where you want to assert that a DSL
+  definition compiles cleanly through all verifiers.
+
+  ## Example
+
+      test "valid configuration is accepted" do
+        refute_dsl_errors do
+          defmodule Elixir.MyExample do
+            use MyApp.Validator
+            # ... valid configuration
+          end
+        end
+      end
+
+  See `dsl_errors/1` if you need access to the full collected list (e.g.
+  when asserting on multiple distinct errors at once), and
+  `refute_dsl_warnings/1` for the warning-side counterpart.
+  """
+  defmacro refute_dsl_errors(do: block) do
+    quote do
+      case Spark.Test.dsl_errors(do: unquote(block)) do
+        [] ->
+          :ok
+
+        collected ->
+          ExUnit.Assertions.flunk("""
+          Expected no Spark.Error.DslError values, got:
+
+          #{inspect(collected, pretty: true)}
+          """)
+      end
+    end
+  end
+
+  @doc """
+  Asserts that the given do-block produces no verifier warnings.
+
+  Returns `:ok` on success. If any warning payloads are collected, the test
+  fails with a message that includes the inspected
+  `[{module, [{message, location | nil}, ...]}]` list, so the offending
+  modules and their warnings are visible in the failure output.
+
+  Use this for happy-path tests where you want to assert that a DSL
+  definition compiles cleanly through all warning-emitting verifiers.
+
+  ## Example
+
+      test "no deprecated options used" do
+        refute_dsl_warnings do
+          defmodule Elixir.MyExample do
+            use MyApp.Validator
+            # ... configuration that uses no deprecated options
+          end
+        end
+      end
+
+  See `dsl_warnings/1` if you need access to the full collected list,
+  and `refute_dsl_errors/1` for the error-side counterpart.
+  """
+  defmacro refute_dsl_warnings(do: block) do
+    quote do
+      case Spark.Test.dsl_warnings(do: unquote(block)) do
+        [] ->
+          :ok
+
+        collected ->
+          ExUnit.Assertions.flunk("""
+          Expected no verifier warnings, got:
+
+          #{inspect(collected, pretty: true)}
+          """)
+      end
+    end
+  end
+
+  @doc false
+  def __drain_errors__(acc) do
+    receive do
+      {Spark.Dsl, :verifier_errors, mod, errs} -> __drain_errors__([{mod, errs} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  @doc false
+  def __drain_warnings__(acc) do
+    receive do
+      {Spark.Dsl, :verifier_warnings, mod, payloads} ->
+        __drain_warnings__([{mod, payloads} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  defp build_assert_error(pattern, block) do
+    pattern_source = Macro.to_string(pattern)
+
+    quote do
+      collected = Spark.Test.dsl_errors(do: unquote(block))
+      all_errors = Enum.flat_map(collected, fn {_mod, errs} -> errs end)
+
+      case Enum.find(all_errors, fn err -> match?(unquote(pattern), err) end) do
+        nil ->
+          ExUnit.Assertions.flunk("""
+          Expected a Spark.Error.DslError matching:
+
+              #{unquote(pattern_source)}
+
+          Got:
+          #{inspect(all_errors, pretty: true)}
+          """)
+
+        err ->
+          err
+      end
+    end
+  end
+
+  defp build_assert_warning(pattern, block) do
+    pattern_source = Macro.to_string(pattern)
+
+    quote do
+      collected = Spark.Test.dsl_warnings(do: unquote(block))
+      all_warnings = Enum.flat_map(collected, fn {_mod, payloads} -> payloads end)
+
+      case Enum.find(all_warnings, fn warn -> match?(unquote(pattern), warn) end) do
+        nil ->
+          ExUnit.Assertions.flunk("""
+          Expected a verifier warning matching:
+
+              #{unquote(pattern_source)}
+
+          Got:
+          #{inspect(all_warnings, pretty: true)}
+          """)
+
+        warn ->
+          warn
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -85,7 +85,8 @@ defmodule Spark.MixProject do
         "documentation/how_to/split-up-large-dsls.md",
         "documentation/how_to/use-source-annotations.md",
         "documentation/how_to/setup-autocomplete.md",
-        "documentation/how_to/build-extensions-with-builders.md"
+        "documentation/how_to/build-extensions-with-builders.md",
+        "documentation/how_to/test-spark-verifiers.md"
       ],
       groups_for_extras: [
         Tutorials: ~r/documentation\/tutorials/,

--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -7,6 +7,7 @@ defmodule Spark.DslTest do
 
   import ExUnit.CaptureIO
   import Spark.CodeHelpers
+  import Spark.Test
 
   setup do
     debug_info? = Code.get_compiler_option(:debug_info)
@@ -294,25 +295,55 @@ defmodule Spark.DslTest do
     end
 
     test "verifiers are run" do
-      import ExUnit.CaptureIO
-
-      base_line = __ENV__.line
-
-      message =
-        capture_io(:stderr, fn ->
-          defmodule Gandalf do
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:personal_details, :first_name]} do
+          defmodule Elixir.Gandalf do
             @moduledoc false
             use Spark.Test.Contact
 
             personal_details do
-              # Line offset: +10
               first_name("Gandalf")
+            end
+          end
+        end
+
+      assert err.message =~ "Cannot be gandalf"
+      assert err.location != nil
+    end
+
+    test "verifier warnings are emitted" do
+      {message, _location} =
+        assert_dsl_warning {_, _} do
+          defmodule Elixir.VerifierWarningEmitter do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert message =~ "fixture warning"
+    end
+
+    test "verifier warnings without a test collector go to stderr" do
+      Process.delete({Spark.Dsl, :test_collector})
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.VerifierWarningStderr do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
             end
           end
         end)
 
-      assert message =~ "Cannot be gandalf"
-      assert message =~ "~~~"
+      assert stderr =~ "fixture warning"
+      refute_received {Spark.Dsl, :verifier_warnings, _, _}
     end
 
     test "extensions can add entities to other entities extensions" do
@@ -335,18 +366,21 @@ defmodule Spark.DslTest do
     end
 
     test "identifiers are honored" do
-      import ExUnit.CaptureIO
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:presets, :foo]} do
+          defmodule Elixir.Squidward do
+            @moduledoc false
+            use Spark.Test.Contact
 
-      assert capture_io(:stderr, fn ->
-               defmodule Squidward do
-                 use Spark.Test.Contact
+            presets do
+              preset(:foo)
+              preset(:foo)
+            end
+          end
+        end
 
-                 presets do
-                   preset(:foo)
-                   preset(:foo)
-                 end
-               end
-             end) =~ "Got duplicate Spark.Test.Contact.Dsl.Preset: foo"
+      assert err.message =~ "Got duplicate Spark.Test.Contact.Dsl.Preset: foo"
+      assert err.location != nil
     end
 
     test "singleton entities are validated" do
@@ -395,23 +429,25 @@ defmodule Spark.DslTest do
     end
 
     test "section singleton_entity_keys rejects multiple entities" do
-      import ExUnit.CaptureIO
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:singleton_section]} do
+          defmodule Elixir.SectionSingletonMultiple do
+            @moduledoc false
+            use Spark.Test.Contact
 
-      assert capture_io(:stderr, fn ->
-               defmodule SectionSingletonMultiple do
-                 @moduledoc false
-                 use Spark.Test.Contact
+            singleton_section do
+              singleton(:first)
+              singleton(:second)
+            end
 
-                 singleton_section do
-                   singleton(:first)
-                   singleton(:second)
-                 end
+            personal_details do
+              first_name("Zach")
+            end
+          end
+        end
 
-                 personal_details do
-                   first_name("Zach")
-                 end
-               end
-             end) =~ "Expected at most one singleton"
+      assert err.message =~ "Expected at most one singleton"
+      assert err.location != nil
     end
   end
 
@@ -810,20 +846,22 @@ defmodule Spark.DslTest do
     end
 
     test "extensions honor identifiers when adding entities to other entities extensions" do
-      import ExUnit.CaptureIO
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:presets, :foo]} do
+          defmodule Elixir.Doc do
+            @moduledoc false
+            use Spark.Test.Contact,
+              extensions: [Spark.Test.ContactPatcher]
 
-      assert capture_io(:stderr, fn ->
-               defmodule Doc do
-                 @moduledoc false
-                 use Spark.Test.Contact,
-                   extensions: [Spark.Test.ContactPatcher]
+            presets do
+              preset(:foo)
+              special_preset(:foo)
+            end
+          end
+        end
 
-                 presets do
-                   preset(:foo)
-                   special_preset(:foo)
-                 end
-               end
-             end) =~ "Got duplicate Spark.Test.Contact.Dsl.Preset: foo"
+      assert err.message =~ "Got duplicate Spark.Test.Contact.Dsl.Preset: foo"
+      assert err.location != nil
     end
   end
 
@@ -969,27 +1007,26 @@ defmodule Spark.DslTest do
 
   describe "error location tracking" do
     test "duplicate entity errors include location information" do
-      import ExUnit.CaptureIO
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:presets, :duplicate_test]} do
+          defmodule Elixir.LocationTestDuplicate do
+            @moduledoc false
+            use Spark.Test.Contact
 
-      error_output =
-        capture_io(:stderr, fn ->
-          try do
-            defmodule LocationTestDuplicate do
-              use Spark.Test.Contact
-
-              presets do
-                preset(:duplicate_test)
-                preset(:duplicate_test)
-              end
+            presets do
+              preset(:duplicate_test)
+              preset(:duplicate_test)
             end
-          rescue
-            _ -> :ok
           end
-        end)
+        end
 
-      # Should include the file and line information
-      assert error_output =~ "dsl_test.exs"
-      assert error_output =~ "Got duplicate"
+      assert err.message =~ "Got duplicate"
+      assert err.location != nil
+
+      assert err.location
+             |> :erl_anno.file()
+             |> to_string()
+             |> Path.basename() == "dsl_test.exs"
     end
 
     test "schema validation errors include location information" do

--- a/test/spark/dsl/test_collector_test.exs
+++ b/test/spark/dsl/test_collector_test.exs
@@ -1,0 +1,560 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Dsl.TestCollectorTest do
+  @moduledoc """
+  Tests for the test-collector hook in `Spark.Dsl.__verify_spark_dsl__/1`.
+
+  When a process has registered itself as a verifier-error collector via
+  `Process.put({Spark.Dsl, :test_collector}, pid)`, verifier errors that
+  would otherwise be raised (and converted to stderr warnings by the
+  `@after_verify` catch block) are instead routed via
+  `send(pid, {Spark.Dsl, :verifier_errors, module, errors})` and the
+  post-error `run_transformers` call is skipped.
+
+  Default behavior (flag unset, or set to a non-pid value) is preserved.
+
+  ## Test convention
+
+  Every `defmodule` defined inside an anonymous function (e.g. inside a
+  `capture_io/2` callback or `Task.async/1` body) uses the explicit
+  `Elixir.SomeName` form. Inside such an anonymous function, a bare alias
+  in a `defmodule` head is resolved against the surrounding test module
+  scope, so `defmodule SomeName` would create `Spark.Dsl.TestCollectorTest.SomeName`.
+  Outside the function (where `assert_received` patterns live), the bare alias
+  `SomeName` resolves to top-level `Elixir.SomeName` — a different atom — and
+  the pattern would never match. Forcing top-level resolution at the defmodule
+  site keeps both sides aligned.
+  """
+
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  setup do
+    debug_info? = Code.get_compiler_option(:debug_info)
+    Code.put_compiler_option(:debug_info, true)
+    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
+    :ok
+  end
+
+  describe "default path (no collector flag)" do
+    test "single verifier error is rendered as a stderr warning" do
+      # Defensive: ensure no flag leaked into this process.
+      Process.delete({Spark.Dsl, :test_collector})
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.DefaultPathGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr =~ "Cannot be gandalf"
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "non-pid collector value falls through to default warn path" do
+      # Setting a non-pid value must not enter the collector branch.
+      # No cleanup needed: with async: true the test process exits and its
+      # process dict is reclaimed automatically.
+      Process.put({Spark.Dsl, :test_collector}, :not_a_pid)
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.NonPidFlagGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr =~ "Cannot be gandalf"
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "multiple errors from one module render the multi-error envelope" do
+      Process.delete({Spark.Dsl, :test_collector})
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.DefaultPathMultiError do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+
+            presets do
+              preset(:foo)
+              preset(:foo)
+            end
+          end
+        end)
+
+      assert stderr =~ "Multiple Errors Occurred"
+      assert stderr =~ "Cannot be gandalf"
+      assert stderr =~ "Got duplicate"
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+  end
+
+  describe "collector branch (flag set to live pid)" do
+    test "single verifier error is routed via send and no warning is emitted" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_errors, CollectedGandalf, errors}
+      assert [%Spark.Error.DslError{} = err] = errors
+      assert err.message =~ "Cannot be gandalf"
+      assert err.path == [:personal_details, :first_name]
+    end
+
+    test "valid module with flag set sends no message and no warning" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedValid do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Zach")
+            end
+          end
+        end)
+
+      assert stderr == ""
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "multiple errors from one module are delivered in a single message" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedMultiError do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+
+            presets do
+              preset(:foo)
+              preset(:foo)
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_errors, CollectedMultiError, errors}
+      assert length(errors) == 2
+
+      assert Enum.any?(errors, fn err ->
+               is_struct(err, Spark.Error.DslError) and err.message =~ "Cannot be gandalf"
+             end)
+
+      assert Enum.any?(errors, fn err ->
+               is_struct(err, Spark.Error.DslError) and err.message =~ "Got duplicate"
+             end)
+
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "each defined module emits its own message in definition order" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedSequenceFirst do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+
+          defmodule Elixir.CollectedSequenceSecond do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+
+          defmodule Elixir.CollectedSequenceValid do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Zach")
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_errors, CollectedSequenceFirst, [_]}
+      assert_received {Spark.Dsl, :verifier_errors, CollectedSequenceSecond, [_]}
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "flag pointing at a dead pid does not crash and emits no warning" do
+      dead = spawn(fn -> :ok end)
+      ref = Process.monitor(dead)
+      assert_receive {:DOWN, ^ref, :process, ^dead, _}, 200
+
+      Process.put({Spark.Dsl, :test_collector}, dead)
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedDeadPidGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr == ""
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "flag pointing at another live process delivers messages to that process" do
+      parent = self()
+
+      child =
+        spawn_link(fn ->
+          receive do
+            {Spark.Dsl, :verifier_errors, _mod, _errs} = msg ->
+              send(parent, {:forwarded, msg})
+          after
+            500 -> send(parent, :timeout)
+          end
+        end)
+
+      Process.put({Spark.Dsl, :test_collector}, child)
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedRemoteGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_receive {:forwarded,
+                      {Spark.Dsl, :verifier_errors, CollectedRemoteGandalf,
+                       [%Spark.Error.DslError{}]}},
+                     500
+    end
+
+    test "flag is re-read on every defmodule, not cached" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr_collected =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedFreshFirst do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr_collected == ""
+      assert_received {Spark.Dsl, :verifier_errors, CollectedFreshFirst, [_]}
+
+      Process.delete({Spark.Dsl, :test_collector})
+
+      stderr_default =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedFreshSecond do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end)
+
+      assert stderr_default =~ "Cannot be gandalf"
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "after-compile transformers do NOT run when errors are collected" do
+      counter_key = {Spark.Test.CollectorFixture, :counter}
+      Process.put(counter_key, 0)
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedTransformerSkipped do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_error(true)
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_errors, CollectedTransformerSkipped,
+                       [%Spark.Error.DslError{message: "fixture error"}]}
+
+      assert Process.get(counter_key) == 0,
+             "after-compile transformer ran despite collected errors"
+    end
+
+    test "after-compile transformers DO run when no errors are produced (flag set)" do
+      counter_key = {Spark.Test.CollectorFixture, :counter}
+      Process.put(counter_key, 0)
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.CollectedTransformerRuns do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_error(false)
+            end
+          end
+        end)
+
+      assert stderr == ""
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+
+      assert Process.get(counter_key) == 1,
+             "after-compile transformer did not run for a valid module"
+    end
+  end
+
+  describe "concurrent isolation" do
+    test "two parallel processes each only see their own collected errors" do
+      task_a =
+        Task.async(fn ->
+          Process.put({Spark.Dsl, :test_collector}, self())
+
+          capture_io(:stderr, fn ->
+            defmodule Elixir.CollectedConcurrentA do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Gandalf")
+              end
+            end
+          end)
+
+          drain_collector_messages([])
+        end)
+
+      task_b =
+        Task.async(fn ->
+          Process.put({Spark.Dsl, :test_collector}, self())
+
+          capture_io(:stderr, fn ->
+            defmodule Elixir.CollectedConcurrentB do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Gandalf")
+              end
+            end
+          end)
+
+          drain_collector_messages([])
+        end)
+
+      a_results = Task.await(task_a, 1_000)
+      b_results = Task.await(task_b, 1_000)
+
+      assert [{CollectedConcurrentA, [%Spark.Error.DslError{}]}] = a_results
+      assert [{CollectedConcurrentB, [%Spark.Error.DslError{}]}] = b_results
+
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+  end
+
+  describe "warning hook" do
+    test "unset flag triggers the default warn-to-stderr path" do
+      Process.delete({Spark.Dsl, :test_collector})
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.WarnDefaultPath do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end)
+
+      assert stderr =~ "fixture warning"
+      refute_received {Spark.Dsl, :verifier_warnings, _, _}
+    end
+
+    test "non-pid collector value falls through to the default warn-to-stderr path" do
+      Process.put({Spark.Dsl, :test_collector}, :not_a_pid)
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.WarnNonPidFlag do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end)
+
+      assert stderr =~ "fixture warning"
+      refute_received {Spark.Dsl, :verifier_warnings, _, _}
+    end
+
+    test "collector pid receives the warning as a single send" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.WarnCollected do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_warnings, WarnCollected, [{"fixture warning", nil}]}
+    end
+
+    test "tuple-form warning {message, anno} is preserved through normalization" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.WarnCollectedTuple do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:tuple)
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_warnings, WarnCollectedTuple, payloads}
+      assert [{"fixture warning with location", anno}] = payloads
+      assert anno != nil
+    end
+
+    test "multiple warnings from one verifier are delivered in a single message" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.WarnCollectedMulti do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:multi)
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_warnings, WarnCollectedMulti, payloads}
+      assert [{"fixture warning a", nil}, {"fixture warning b", anno}] = payloads
+      assert anno != nil
+    end
+
+    test "errors and warnings from one module are routed via their own tags" do
+      Process.put({Spark.Dsl, :test_collector}, self())
+
+      stderr =
+        capture_io(:stderr, fn ->
+          defmodule Elixir.WarnAndErrorCollected do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_error(true)
+              trigger_warning(:bare)
+            end
+          end
+        end)
+
+      assert stderr == ""
+
+      assert_received {Spark.Dsl, :verifier_errors, WarnAndErrorCollected,
+                       [%Spark.Error.DslError{message: "fixture error"}]}
+
+      assert_received {Spark.Dsl, :verifier_warnings, WarnAndErrorCollected,
+                       [{"fixture warning", nil}]}
+    end
+  end
+
+  defp drain_collector_messages(acc) do
+    receive do
+      {Spark.Dsl, :verifier_errors, mod, errs} -> drain_collector_messages([{mod, errs} | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+end

--- a/test/spark/test/assert_dsl_error_test.exs
+++ b/test/spark/test/assert_dsl_error_test.exs
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.AssertDslErrorTest do
+  @moduledoc """
+  Tests for `Spark.Test.assert_dsl_error/1` and `Spark.Test.assert_dsl_error/2` —
+  pattern-match a single collected verifier error.
+
+  Modules defined inside the macro's anonymous-function body use the
+  `Elixir.SomeName` form so that the bare alias used in outer assertions
+  resolves to the same atom (see `Spark.Test.DslErrorsTest` and
+  `Spark.Dsl.TestCollectorTest` for the same convention).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  describe "assert_dsl_error/2" do
+    test "passes when a matching error exists and returns the matched error" do
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:personal_details, :first_name]} do
+          defmodule Elixir.AssertMatchGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert %Spark.Error.DslError{} = err
+      assert err.message =~ "Cannot be gandalf"
+      assert err.path == [:personal_details, :first_name]
+    end
+
+    test "pattern with non-literal field positions matches correctly" do
+      # `_` and bound names in field positions exercise match?'s pattern semantics
+      # (it must accept any value, not require a literal).
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:personal_details, _], message: _msg} do
+          defmodule Elixir.AssertWildcardGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert err.path == [:personal_details, :first_name]
+    end
+
+    test "fails with a helpful message when no errors are collected" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_dsl_error %Spark.Error.DslError{path: [:personal_details, :first_name]} do
+            defmodule Elixir.AssertNoErrorsValid do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Zach")
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "Spark.Error.DslError"
+      assert failure.message =~ ":personal_details"
+      assert failure.message =~ "Got:"
+    end
+
+    test "fails with a helpful message when errors exist but none match" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_dsl_error %Spark.Error.DslError{path: [:something_else]} do
+            defmodule Elixir.AssertNoMatchGandalf do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Gandalf")
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ ":something_else"
+      assert failure.message =~ "Cannot be gandalf"
+    end
+
+    test "returns the first matching error in definition order when multiple match" do
+      err =
+        assert_dsl_error %Spark.Error.DslError{path: [:personal_details, :first_name]} do
+          defmodule Elixir.AssertFirstMatchOne do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+
+          defmodule Elixir.AssertFirstMatchTwo do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert err.module == AssertFirstMatchOne
+    end
+  end
+
+  describe "assert_dsl_error/1" do
+    test "passes when any error exists and returns the first one" do
+      err =
+        assert_dsl_error do
+          defmodule Elixir.AssertAnyGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert %Spark.Error.DslError{} = err
+      assert err.message =~ "Cannot be gandalf"
+    end
+
+    test "fails with a helpful message when no errors exist" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_dsl_error do
+            defmodule Elixir.AssertAnyValid do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Zach")
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "Spark.Error.DslError"
+      assert failure.message =~ "Got:"
+    end
+  end
+end

--- a/test/spark/test/assert_dsl_warning_test.exs
+++ b/test/spark/test/assert_dsl_warning_test.exs
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.AssertDslWarningTest do
+  @moduledoc """
+  Tests for `Spark.Test.assert_dsl_warning/1` and
+  `Spark.Test.assert_dsl_warning/2` — pattern-match a single collected
+  verifier warning payload.
+
+  Modules defined inside the macro's anonymous-function body use the
+  `Elixir.SomeName` form so that the bare alias used in outer assertions
+  resolves to the same atom (see `Spark.Test.DslWarningsTest` and
+  `Spark.Dsl.TestCollectorTest` for the convention).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  setup do
+    debug_info? = Code.get_compiler_option(:debug_info)
+    Code.put_compiler_option(:debug_info, true)
+    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
+    :ok
+  end
+
+  describe "assert_dsl_warning/2" do
+    test "passes when a matching warning exists and returns the matched payload" do
+      payload =
+        assert_dsl_warning {"fixture warning", _location} do
+          defmodule Elixir.AssertWarnMatchBare do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert {message, nil} = payload
+      assert message == "fixture warning"
+    end
+
+    test "pattern with non-literal positions matches correctly" do
+      payload =
+        assert_dsl_warning {_message, _location} do
+          defmodule Elixir.AssertWarnWildcard do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:tuple)
+            end
+          end
+        end
+
+      assert {"fixture warning with location", anno} = payload
+      assert anno != nil
+    end
+
+    test "fails with a helpful message when no warnings are collected" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_dsl_warning {"fixture warning", _} do
+            defmodule Elixir.AssertWarnNoneClean do
+              @moduledoc false
+              use Spark.Test.CollectorFixture
+            end
+          end
+        end
+
+      assert failure.message =~ "verifier warning"
+      assert failure.message =~ "fixture warning"
+      assert failure.message =~ "Got:"
+    end
+
+    test "fails with a helpful message when warnings exist but none match" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_dsl_warning {"some other text", _} do
+            defmodule Elixir.AssertWarnNoMatch do
+              @moduledoc false
+              use Spark.Test.CollectorFixture
+
+              fixture do
+                trigger_warning(:bare)
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "some other text"
+      assert failure.message =~ "fixture warning"
+    end
+
+    test "returns the first matching warning in definition order when multiple match" do
+      payload =
+        assert_dsl_warning {_message, _location} do
+          defmodule Elixir.AssertWarnFirstBare do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+
+          defmodule Elixir.AssertWarnFirstTuple do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:tuple)
+            end
+          end
+        end
+
+      # Definition order is :bare first → first match is the bare-shape payload.
+      assert {"fixture warning", nil} = payload
+    end
+  end
+
+  describe "assert_dsl_warning/1" do
+    test "passes when any warning exists and returns the first one" do
+      payload =
+        assert_dsl_warning do
+          defmodule Elixir.AssertWarnAny do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert {"fixture warning", nil} = payload
+    end
+
+    test "fails with a helpful message when no warnings exist" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_dsl_warning do
+            defmodule Elixir.AssertWarnAnyClean do
+              @moduledoc false
+              use Spark.Test.CollectorFixture
+            end
+          end
+        end
+
+      assert failure.message =~ "verifier warning"
+      assert failure.message =~ "Got:"
+    end
+  end
+end

--- a/test/spark/test/dsl_errors_test.exs
+++ b/test/spark/test/dsl_errors_test.exs
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.DslErrorsTest do
+  @moduledoc """
+  Tests for `Spark.Test.dsl_errors/1` — collects verifier errors raised by
+  Spark DSL modules defined inside the macro's do-block, returning them as
+  structured data.
+
+  Modules defined inside the macro's anonymous-function body use the
+  `Elixir.SomeName` form so that the bare alias used in outer assertions
+  resolves to the same atom (see `Spark.Dsl.TestCollectorTest` for the same
+  convention and the underlying Elixir alias-scoping rationale).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  doctest Spark.Test
+
+  describe "dsl_errors/1" do
+    test "empty block returns empty list" do
+      assert dsl_errors(do: :ok) == []
+    end
+
+    test "one bad DSL module returns one entry with its errors" do
+      result =
+        dsl_errors do
+          defmodule Elixir.OneBadGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert [{OneBadGandalf, [%Spark.Error.DslError{} = err]}] = result
+      assert err.message =~ "Cannot be gandalf"
+      assert err.path == [:personal_details, :first_name]
+    end
+
+    test "one valid DSL module returns empty list" do
+      result =
+        dsl_errors do
+          defmodule Elixir.OneValidContact do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Zach")
+            end
+          end
+        end
+
+      assert result == []
+    end
+
+    test "multiple bad modules return entries in definition order" do
+      result =
+        dsl_errors do
+          defmodule Elixir.MultiOrderOne do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+
+          defmodule Elixir.MultiOrderTwo do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+
+          defmodule Elixir.MultiOrderThree do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert [
+               {MultiOrderOne, [%Spark.Error.DslError{}]},
+               {MultiOrderTwo, [%Spark.Error.DslError{}]},
+               {MultiOrderThree, [%Spark.Error.DslError{}]}
+             ] = result
+    end
+
+    test "one module producing multiple errors returns them all" do
+      result =
+        dsl_errors do
+          defmodule Elixir.MultiErrorPerModule do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+
+            presets do
+              preset(:foo)
+              preset(:foo)
+            end
+          end
+        end
+
+      assert [{MultiErrorPerModule, errors}] = result
+      assert length(errors) == 2
+
+      assert Enum.any?(errors, fn err ->
+               is_struct(err, Spark.Error.DslError) and err.message =~ "Cannot be gandalf"
+             end)
+
+      assert Enum.any?(errors, fn err ->
+               is_struct(err, Spark.Error.DslError) and err.message =~ "Got duplicate"
+             end)
+    end
+
+    test "exception in block propagates and flag is cleaned up" do
+      assert Process.get({Spark.Dsl, :test_collector}) == nil
+
+      assert_raise RuntimeError, "boom", fn ->
+        dsl_errors do
+          raise "boom"
+        end
+      end
+
+      assert Process.get({Spark.Dsl, :test_collector}) == nil
+    end
+
+    test "previous collector flag value is restored after the call" do
+      Process.put({Spark.Dsl, :test_collector}, :prior_marker)
+
+      try do
+        assert dsl_errors(do: :ok) == []
+        assert Process.get({Spark.Dsl, :test_collector}) == :prior_marker
+      after
+        Process.delete({Spark.Dsl, :test_collector})
+      end
+    end
+
+    test "does not consume unrelated mailbox messages" do
+      send(self(), :keep_a)
+      send(self(), {:other, 42})
+
+      result =
+        dsl_errors do
+          defmodule Elixir.HygieneGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert [{HygieneGandalf, [_]}] = result
+
+      assert_received :keep_a
+      assert_received {:other, 42}
+    end
+
+    test "nested invocation: inner does not leak to outer" do
+      outer =
+        dsl_errors do
+          inner =
+            dsl_errors do
+              defmodule Elixir.NestedInnerGandalf do
+                @moduledoc false
+                use Spark.Test.Contact
+
+                personal_details do
+                  first_name("Gandalf")
+                end
+              end
+            end
+
+          send(self(), {:inner_result, inner})
+
+          defmodule Elixir.NestedOuterGandalf do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Gandalf")
+            end
+          end
+        end
+
+      assert [{NestedOuterGandalf, [_]}] = outer
+      assert_received {:inner_result, inner}
+      assert [{NestedInnerGandalf, [_]}] = inner
+    end
+
+    test "drains warnings from the mailbox after the call" do
+      result =
+        dsl_errors do
+          defmodule Elixir.DslErrorsCrossDrain do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_error(true)
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [{DslErrorsCrossDrain, [%Spark.Error.DslError{message: "fixture error"}]}] = result
+      refute_received {Spark.Dsl, :verifier_warnings, _, _}
+    end
+  end
+end

--- a/test/spark/test/dsl_warnings_test.exs
+++ b/test/spark/test/dsl_warnings_test.exs
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.DslWarningsTest do
+  @moduledoc """
+  Tests for `Spark.Test.dsl_warnings/1` — collects verifier warnings raised by
+  Spark DSL modules defined inside the macro's do-block, returning them as
+  structured `[{module, [{message, location | nil}, ...]}, ...]` data.
+
+  Modules defined inside the macro's anonymous-function body use the
+  `Elixir.SomeName` form so that the bare alias used in outer assertions
+  resolves to the same atom (see `Spark.Test.DslErrorsTest` and
+  `Spark.Dsl.TestCollectorTest` for the convention).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  setup do
+    debug_info? = Code.get_compiler_option(:debug_info)
+    Code.put_compiler_option(:debug_info, true)
+    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
+    :ok
+  end
+
+  describe "dsl_warnings/1" do
+    test "empty block returns empty list" do
+      assert dsl_warnings(do: :ok) == []
+    end
+
+    test "one DSL module with a warning returns one entry with its payloads" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.OneWarningFixture do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [{OneWarningFixture, [{"fixture warning", nil}]}] = result
+    end
+
+    test "one valid DSL module returns empty list" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.OneCleanFixture do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+          end
+        end
+
+      assert result == []
+    end
+
+    test "multiple modules with warnings return entries in definition order" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.MultiWarnOne do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+
+          defmodule Elixir.MultiWarnTwo do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+
+          defmodule Elixir.MultiWarnThree do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [
+               {MultiWarnOne, [{"fixture warning", nil}]},
+               {MultiWarnTwo, [{"fixture warning", nil}]},
+               {MultiWarnThree, [{"fixture warning", nil}]}
+             ] = result
+    end
+
+    test "one module producing multiple warnings returns them all" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.MultiWarnPerModule do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:multi)
+            end
+          end
+        end
+
+      assert [{MultiWarnPerModule, payloads}] = result
+      assert [{"fixture warning a", nil}, {"fixture warning b", anno}] = payloads
+      assert anno != nil
+    end
+
+    test "exception in block propagates and flag is cleaned up" do
+      assert Process.get({Spark.Dsl, :test_collector}) == nil
+
+      assert_raise RuntimeError, "boom", fn ->
+        dsl_warnings do
+          raise "boom"
+        end
+      end
+
+      assert Process.get({Spark.Dsl, :test_collector}) == nil
+    end
+
+    test "previous collector flag value is restored after the call" do
+      Process.put({Spark.Dsl, :test_collector}, :prior_marker)
+
+      try do
+        assert dsl_warnings(do: :ok) == []
+        assert Process.get({Spark.Dsl, :test_collector}) == :prior_marker
+      after
+        Process.delete({Spark.Dsl, :test_collector})
+      end
+    end
+
+    test "does not consume unrelated mailbox messages" do
+      send(self(), :keep_a)
+      send(self(), {:other, 42})
+
+      result =
+        dsl_warnings do
+          defmodule Elixir.HygieneWarnFixture do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [{HygieneWarnFixture, [{"fixture warning", nil}]}] = result
+
+      assert_received :keep_a
+      assert_received {:other, 42}
+    end
+
+    test "nested invocation: inner does not leak to outer" do
+      outer =
+        dsl_warnings do
+          inner =
+            dsl_warnings do
+              defmodule Elixir.NestedInnerWarn do
+                @moduledoc false
+                use Spark.Test.CollectorFixture
+
+                fixture do
+                  trigger_warning(:bare)
+                end
+              end
+            end
+
+          send(self(), {:inner_result, inner})
+
+          defmodule Elixir.NestedOuterWarn do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [{NestedOuterWarn, [{"fixture warning", nil}]}] = outer
+      assert_received {:inner_result, inner}
+      assert [{NestedInnerWarn, [{"fixture warning", nil}]}] = inner
+    end
+
+    test "drains errors from the mailbox after the call" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.DslWarningsCrossDrain do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_error(true)
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [{DslWarningsCrossDrain, [{"fixture warning", nil}]}] = result
+      refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+  end
+end

--- a/test/spark/test/refute_dsl_errors_test.exs
+++ b/test/spark/test/refute_dsl_errors_test.exs
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.RefuteDslErrorsTest do
+  @moduledoc """
+  Tests for `Spark.Test.refute_dsl_errors/1` — assert that no verifier errors
+  are produced by DSL modules defined inside the do-block.
+
+  Modules defined inside the macro's anonymous-function body use the
+  `Elixir.SomeName` form so that the bare alias used in outer assertions
+  resolves to the same atom (see `Spark.Test.DslErrorsTest` and
+  `Spark.Dsl.TestCollectorTest` for the convention).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  describe "refute_dsl_errors/1" do
+    test "passes when block defines no DSL modules" do
+      assert refute_dsl_errors(do: :ok) == :ok
+    end
+
+    test "passes when DSL modules compile cleanly" do
+      result =
+        refute_dsl_errors do
+          defmodule Elixir.RefuteValidContact do
+            @moduledoc false
+            use Spark.Test.Contact
+
+            personal_details do
+              first_name("Zach")
+            end
+          end
+        end
+
+      assert result == :ok
+    end
+
+    test "fails with a helpful message when an error exists" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_dsl_errors do
+            defmodule Elixir.RefuteBadGandalf do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Gandalf")
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "Expected no Spark.Error.DslError"
+      assert failure.message =~ "Cannot be gandalf"
+      assert failure.message =~ "RefuteBadGandalf"
+    end
+
+    test "fails when multiple modules produce errors and lists all of them" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_dsl_errors do
+            defmodule Elixir.RefuteMultiOne do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Gandalf")
+              end
+            end
+
+            defmodule Elixir.RefuteMultiTwo do
+              @moduledoc false
+              use Spark.Test.Contact
+
+              personal_details do
+                first_name("Gandalf")
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "RefuteMultiOne"
+      assert failure.message =~ "RefuteMultiTwo"
+    end
+  end
+end

--- a/test/spark/test/refute_dsl_warnings_test.exs
+++ b/test/spark/test/refute_dsl_warnings_test.exs
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.RefuteDslWarningsTest do
+  @moduledoc """
+  Tests for `Spark.Test.refute_dsl_warnings/1` — assert that no verifier
+  warnings are produced by DSL modules defined inside the do-block.
+
+  Modules defined inside the macro's anonymous-function body use the
+  `Elixir.SomeName` form so that the bare alias used in outer assertions
+  resolves to the same atom (see `Spark.Test.DslWarningsTest` and
+  `Spark.Dsl.TestCollectorTest` for the convention).
+  """
+
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  setup do
+    debug_info? = Code.get_compiler_option(:debug_info)
+    Code.put_compiler_option(:debug_info, true)
+    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
+    :ok
+  end
+
+  describe "refute_dsl_warnings/1" do
+    test "passes when block defines no DSL modules" do
+      assert refute_dsl_warnings(do: :ok) == :ok
+    end
+
+    test "passes when DSL modules compile cleanly" do
+      result =
+        refute_dsl_warnings do
+          defmodule Elixir.RefuteWarnValid do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+          end
+        end
+
+      assert result == :ok
+    end
+
+    test "fails with a helpful message when a warning exists" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_dsl_warnings do
+            defmodule Elixir.RefuteWarnBare do
+              @moduledoc false
+              use Spark.Test.CollectorFixture
+
+              fixture do
+                trigger_warning(:bare)
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "Expected no verifier warnings"
+      assert failure.message =~ "fixture warning"
+      assert failure.message =~ "RefuteWarnBare"
+    end
+
+    test "fails when multiple modules produce warnings and lists all of them" do
+      failure =
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_dsl_warnings do
+            defmodule Elixir.RefuteWarnMultiOne do
+              @moduledoc false
+              use Spark.Test.CollectorFixture
+
+              fixture do
+                trigger_warning(:bare)
+              end
+            end
+
+            defmodule Elixir.RefuteWarnMultiTwo do
+              @moduledoc false
+              use Spark.Test.CollectorFixture
+
+              fixture do
+                trigger_warning(:bare)
+              end
+            end
+          end
+        end
+
+      assert failure.message =~ "RefuteWarnMultiOne"
+      assert failure.message =~ "RefuteWarnMultiTwo"
+    end
+  end
+end

--- a/test/support/collector_fixture.ex
+++ b/test/support/collector_fixture.ex
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 spark contributors <https://github.com/ash-project/spark/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Spark.Test.CollectorFixture do
+  @moduledoc false
+  # Fixture DSL used to test the test-collector hook in
+  # `Spark.Dsl.__verify_spark_dsl__/1`.
+  #
+  # Provides:
+  #   * a `:fixture` section with a `:trigger_error` boolean option
+  #   * a verifier that returns `{:error, _}` when `trigger_error: true`
+  #   * an after-compile transformer that increments a process-dict counter
+  #     under the key `{Spark.Test.CollectorFixture, :counter}`
+  #
+  # Tests use the counter to observe whether the after-compile transformer
+  # ran; the transformer must NOT run when the verifier produced errors.
+
+  defmodule Dsl do
+    @moduledoc false
+
+    @section %Spark.Dsl.Section{
+      name: :fixture,
+      schema: [
+        trigger_error: [type: :boolean, default: false],
+        trigger_warning: [
+          type: {:in, [false, :bare, :tuple, :multi]},
+          default: false
+        ]
+      ]
+    }
+
+    defmodule MaybeError do
+      @moduledoc false
+      use Spark.Dsl.Verifier
+
+      def verify(dsl) do
+        if Spark.Dsl.Verifier.get_option(dsl, [:fixture], :trigger_error) do
+          {:error,
+           Spark.Error.DslError.exception(
+             message: "fixture error",
+             path: [:fixture],
+             module: Spark.Dsl.Verifier.get_persisted(dsl, :module)
+           )}
+        else
+          :ok
+        end
+      end
+    end
+
+    defmodule MaybeWarning do
+      @moduledoc false
+      use Spark.Dsl.Verifier
+
+      def verify(dsl) do
+        case Spark.Dsl.Verifier.get_option(dsl, [:fixture], :trigger_warning) do
+          false ->
+            :ok
+
+          :bare ->
+            {:warn, "fixture warning"}
+
+          :tuple ->
+            loc = Spark.Dsl.Transformer.get_section_anno(dsl, [:fixture])
+            {:warn, {"fixture warning with location", loc}}
+
+          :multi ->
+            loc = Spark.Dsl.Transformer.get_section_anno(dsl, [:fixture])
+            {:warn, ["fixture warning a", {"fixture warning b", loc}]}
+        end
+      end
+    end
+
+    defmodule BumpCounter do
+      @moduledoc false
+      use Spark.Dsl.Transformer
+
+      def after_compile?, do: true
+
+      def transform(dsl) do
+        key = {Spark.Test.CollectorFixture, :counter}
+        Process.put(key, (Process.get(key) || 0) + 1)
+        {:ok, dsl}
+      end
+    end
+
+    use Spark.Dsl.Extension,
+      sections: [@section],
+      verifiers: [MaybeError, MaybeWarning],
+      transformers: [BumpCounter]
+  end
+
+  use Spark.Dsl, default_extensions: [extensions: Dsl]
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md)
- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies

testing verifiers can be a bit of a pain. this PR proposes helpers in Spark.Test that allows tests to capture the output of the verifiers, and provide helpers to check if/what error/warning happened. 

when outside of tests using these helpers and during normal compilation the behavior is unchanged. 

this PR also refactors the verifier error tests to use the new helpers, and add verifier warning tests, which were missing.

opus 4.7 was used to write the doc and help with the tests.