### PR TITLE
fix : Spark.Test now ignores empty warnings 

### DIFF
--- a/documentation/how_to/test-spark-verifiers.md
+++ b/documentation/how_to/test-spark-verifiers.md
@@ -147,7 +147,9 @@ The same three helpers exist (`dsl_warnings/1`, `assert_dsl_warning/2,/1`,
 **Warnings are normalized to `{message, location | nil}` tuples**, not
 `Spark.Error.DslError` structs. A bare-string warning `{:warn, "msg"}`
 becomes `{"msg", nil}`; a tuple-form warning `{:warn, {"msg", anno}}`
-preserves the location.
+preserves the location. Source annotations require `debug_info` to be
+enabled for tests — see [Asserting on source
+annotations](#asserting-on-source-annotations) below.
 
 ```elixir
 test "deprecated option emits a warning" do
@@ -191,9 +193,9 @@ errors counterparts, just with the warning payload shape.
 
 ## Asserting on source annotations
 
-Spark only captures `:erl_anno.anno()` when `debug_info` is on. Modules
-compiled at runtime inside the helpers don't inherit Mix's project options,
-so add this to your `mix.exs`:
+Spark only captures `:erl_anno.anno()` when `debug_info` is enabled. To
+enable it for runtime modules compiled inside the helpers, add the
+following to your `mix.exs`:
 
 ```elixir
 test_elixirc_options: [debug_info: true]

--- a/documentation/how_to/test-spark-verifiers.md
+++ b/documentation/how_to/test-spark-verifiers.md
@@ -189,6 +189,19 @@ errors counterparts, just with the warning payload shape.
   `Spark.Dsl.Transformer.transform/1` flow through a separate code path
   and are not collected.
 
+## Asserting on source annotations
+
+Spark only captures `:erl_anno.anno()` when `debug_info` is on. Modules
+compiled at runtime inside the helpers don't inherit Mix's project options,
+so add this to your `mix.exs`:
+
+```elixir
+test_elixirc_options: [debug_info: true]
+```
+
+Without it, `location` in `{message, location}` payloads is `nil` even when
+the verifier passes the anno correctly.
+
 ## Async safety
 
 The helpers are safe in `async: true` ExUnit tests. The collection

--- a/lib/spark/test.ex
+++ b/lib/spark/test.ex
@@ -340,7 +340,6 @@ defmodule Spark.Test do
   @doc false
   def __drain_errors__(acc) do
     receive do
-      {Spark.Dsl, :verifier_errors, _mod, []} -> __drain_errors__(acc)
       {Spark.Dsl, :verifier_errors, mod, errs} -> __drain_errors__([{mod, errs} | acc])
     after
       0 -> Enum.reverse(acc)

--- a/lib/spark/test.ex
+++ b/lib/spark/test.ex
@@ -340,6 +340,7 @@ defmodule Spark.Test do
   @doc false
   def __drain_errors__(acc) do
     receive do
+      {Spark.Dsl, :verifier_errors, _mod, []} -> __drain_errors__(acc)
       {Spark.Dsl, :verifier_errors, mod, errs} -> __drain_errors__([{mod, errs} | acc])
     after
       0 -> Enum.reverse(acc)
@@ -349,6 +350,9 @@ defmodule Spark.Test do
   @doc false
   def __drain_warnings__(acc) do
     receive do
+      {Spark.Dsl, :verifier_warnings, _mod, []} ->
+        __drain_warnings__(acc)
+
       {Spark.Dsl, :verifier_warnings, mod, payloads} ->
         __drain_warnings__([{mod, payloads} | acc])
     after

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,7 @@ defmodule Spark.MixProject do
           parser_columns: true
         ]
       ],
+      test_elixirc_options: [debug_info: true],
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),

--- a/test/spark/dsl/test_collector_test.exs
+++ b/test/spark/dsl/test_collector_test.exs
@@ -32,13 +32,6 @@ defmodule Spark.Dsl.TestCollectorTest do
 
   import ExUnit.CaptureIO
 
-  setup do
-    debug_info? = Code.get_compiler_option(:debug_info)
-    Code.put_compiler_option(:debug_info, true)
-    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
-    :ok
-  end
-
   describe "default path (no collector flag)" do
     test "single verifier error is rendered as a stderr warning" do
       # Defensive: ensure no flag leaked into this process.

--- a/test/spark/test/assert_dsl_warning_test.exs
+++ b/test/spark/test/assert_dsl_warning_test.exs
@@ -18,13 +18,6 @@ defmodule Spark.Test.AssertDslWarningTest do
 
   import Spark.Test
 
-  setup do
-    debug_info? = Code.get_compiler_option(:debug_info)
-    Code.put_compiler_option(:debug_info, true)
-    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
-    :ok
-  end
-
   describe "assert_dsl_warning/2" do
     test "passes when a matching warning exists and returns the matched payload" do
       payload =

--- a/test/spark/test/dsl_warnings_test.exs
+++ b/test/spark/test/dsl_warnings_test.exs
@@ -18,13 +18,6 @@ defmodule Spark.Test.DslWarningsTest do
 
   import Spark.Test
 
-  setup do
-    debug_info? = Code.get_compiler_option(:debug_info)
-    Code.put_compiler_option(:debug_info, true)
-    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
-    :ok
-  end
-
   describe "dsl_warnings/1" do
     test "empty block returns empty list" do
       assert dsl_warnings(do: :ok) == []
@@ -207,6 +200,47 @@ defmodule Spark.Test.DslWarningsTest do
 
       assert [{DslWarningsCrossDrain, [{"fixture warning", nil}]}] = result
       refute_received {Spark.Dsl, :verifier_errors, _, _}
+    end
+
+    test "modules whose verifiers return an empty warning list produce no entry" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.DslWarningsEmpty do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:empty)
+            end
+          end
+        end
+
+      assert result == []
+    end
+
+    test "modules with empty warnings are filtered out of mixed results" do
+      result =
+        dsl_warnings do
+          defmodule Elixir.DslWarningsMixedEmpty do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:empty)
+            end
+          end
+
+          defmodule Elixir.DslWarningsMixedActual do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:bare)
+            end
+          end
+        end
+
+      assert [{DslWarningsMixedActual, [{"fixture warning", nil}]}] = result
     end
   end
 end

--- a/test/spark/test/refute_dsl_warnings_test.exs
+++ b/test/spark/test/refute_dsl_warnings_test.exs
@@ -17,13 +17,6 @@ defmodule Spark.Test.RefuteDslWarningsTest do
 
   import Spark.Test
 
-  setup do
-    debug_info? = Code.get_compiler_option(:debug_info)
-    Code.put_compiler_option(:debug_info, true)
-    on_exit(fn -> Code.put_compiler_option(:debug_info, debug_info?) end)
-    :ok
-  end
-
   describe "refute_dsl_warnings/1" do
     test "passes when block defines no DSL modules" do
       assert refute_dsl_warnings(do: :ok) == :ok
@@ -87,6 +80,22 @@ defmodule Spark.Test.RefuteDslWarningsTest do
 
       assert failure.message =~ "RefuteWarnMultiOne"
       assert failure.message =~ "RefuteWarnMultiTwo"
+    end
+
+    test "passes when a verifier returns an empty warning list" do
+      result =
+        refute_dsl_warnings do
+          defmodule Elixir.RefuteWarnEmpty do
+            @moduledoc false
+            use Spark.Test.CollectorFixture
+
+            fixture do
+              trigger_warning(:empty)
+            end
+          end
+        end
+
+      assert result == :ok
     end
   end
 end

--- a/test/support/collector_fixture.ex
+++ b/test/support/collector_fixture.ex
@@ -24,7 +24,7 @@ defmodule Spark.Test.CollectorFixture do
       schema: [
         trigger_error: [type: :boolean, default: false],
         trigger_warning: [
-          type: {:in, [false, :bare, :tuple, :multi]},
+          type: {:in, [false, :empty, :bare, :tuple, :multi]},
           default: false
         ]
       ]
@@ -56,6 +56,9 @@ defmodule Spark.Test.CollectorFixture do
         case Spark.Dsl.Verifier.get_option(dsl, [:fixture], :trigger_warning) do
           false ->
             :ok
+
+          :empty ->
+            {:warn, []}
 
           :bare ->
             {:warn, "fixture warning"}


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md).
- [X] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies

Following PR #272, i realized that some verifiers returns `{:warn, []}`, breaking the test helpers. Now, the helpers treat this return as no warnings. 
Ash's `Ash.Resource.Verifiers.VerifyActionsAtomic` and `Ash.Resource.Verifiers.VerifyCalculations` returns `{:warn, []}` when no warnings are created, so this fix is needed to be compatible with Ash. 

I also found out that I misunderstood how elixir handles the `debug_info` flag during tests, so i updated the tests and the documentation. 
During test, `elixirc_options` are not followed for code compilation, but `test_elixirc_options` are followed. Do `test_elixirc_options: [debug_info: true],` needs to be added to the project's `mix.exs` to have the `debug_info` flag reliably set. 
Using setup to set the flag was flaky, and it seems it failed in #274 's pipeline.

Also added 3 new tests for around the `{:warn, []}` behavior.