### PR TITLE
fix: resolve Elixir 1.20 compilation warnings

### DIFF
--- a/lib/spark/code_helpers.ex
+++ b/lib/spark/code_helpers.ex
@@ -187,31 +187,6 @@ defmodule Spark.CodeHelpers do
     end
   end
 
-  def lift_functions(value, key, caller) when is_list(value) do
-    if Keyword.keyword?(value) do
-      Enum.reduce(value, {[], nil}, fn {k, v}, {keyword, funs} ->
-        {v, functions} = lift_functions(v, key, caller)
-
-        funs =
-          if functions do
-            quote do
-              unquote(funs)
-              unquote(functions)
-            end
-          else
-            funs
-          end
-
-        {[{k, v} | keyword], funs}
-      end)
-      |> then(fn {keyword, funs} ->
-        {Enum.reverse(keyword), funs}
-      end)
-    else
-      {value, nil}
-    end
-  end
-
   def lift_functions({:&, _, [{:/, _, [{{:., _, _}, _, _}, _]}]} = value, _key, _caller),
     do: {value, nil}
 

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -2078,7 +2078,7 @@ defmodule Spark.Dsl.Extension do
         Task.async(fun)
 
       _ ->
-        Kernel.ParallelCompiler.async(fun)
+        Kernel.ParallelCompiler.pmap([nil], fn _ -> fun.() end)
     end
   end
 

--- a/lib/spark/formatter.ex
+++ b/lib/spark/formatter.ex
@@ -554,8 +554,6 @@ else
     """
     @behaviour Mix.Tasks.Format
 
-    require Logger
-
     def features(_opts) do
       [extensions: [".ex", ".exs"]]
     end

--- a/lib/spark/options/docs.ex
+++ b/lib/spark/options/docs.ex
@@ -534,9 +534,6 @@ defmodule Spark.Options.Docs do
       {:mfa_or_fun, arity} ->
         quote do: unquote(type_to_spec(:mfa)) | unquote(type_to_spec({:fun, arity}))
 
-      {:struct, module} ->
-        quote do: unquote(module).t()
-
       {:wrap_list, type} ->
         quote do: unquote(type_to_spec(type)) | [unquote(type_to_spec(type))]
 

--- a/lib/spark/options/options.ex
+++ b/lib/spark/options/options.ex
@@ -1823,10 +1823,6 @@ defmodule Spark.Options do
     {:ok, {:mfa_or_fun, integer}}
   end
 
-  def validate_type(:struct) do
-    {:ok, :struct}
-  end
-
   def validate_type({:struct, module}) when is_atom(module) do
     {:ok, {:struct, module}}
   end
@@ -1967,14 +1963,6 @@ defmodule Spark.Options do
     {:ok, {:map, valid_key_type, valid_values_type}}
   catch
     {:error, reason} -> {:error, reason}
-  end
-
-  def validate_type({:struct, struct_name}) when is_atom(struct_name) do
-    {:ok, {:struct, struct_name}}
-  end
-
-  def validate_type({:struct, struct_name}) do
-    {:error, "invalid struct_name for :struct, expected atom, got #{inspect(struct_name)}"}
   end
 
   def validate_type(value) do


### PR DESCRIPTION
Resolve all compilation warnings in Elixir 1.20.

- Remove unused `require Logger` in formatter.ex
- Remove redundant `{:struct, module}` clause in type_to_spec (already covered by prior catch-all)
- Remove duplicate `lift_functions/3` list clause in code_helpers.ex
- Remove redundant `validate_type(:struct)` (covered by `@basic_types`)
- Remove duplicate `validate_type({:struct, struct_name})` clauses
- Replace deprecated `Kernel.ParallelCompiler.async/1` with `pmap/2`