### PR TITLE
fix: revert do_async_compile Kernel.ParallelCompiler.pmap introduction

### DIFF
--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -2078,7 +2078,7 @@ defmodule Spark.Dsl.Extension do
         Task.async(fun)
 
       _ ->
-        Kernel.ParallelCompiler.pmap([nil], fn _ -> fun.() end)
+        Kernel.ParallelCompiler.async(fun)
     end
   end
 


### PR DESCRIPTION

# Contributor checklist

This PR reverts change done in #278
I've confirmed it works by pointing my local app at this fork of spark 2.7.1



Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
