### PR TITLE
Use pmap for parallel compilation on Elixir 1.16+

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 28.3.1
-elixir 1.20.0
+erlang 29.0
+elixir 1.20.0-otp-29
 pipx   1.8.0

--- a/lib/spark/dsl/extension.ex
+++ b/lib/spark/dsl/extension.ex
@@ -709,7 +709,7 @@ defmodule Spark.Dsl.Extension do
             spark_dsl_config,
             __ENV__
           )
-          |> Spark.Dsl.Extension.await_tasks()
+          |> Spark.Dsl.Extension.await_persisted_compile_funs()
         rescue
           e in Spark.Error.DslError ->
             if e.location do
@@ -739,9 +739,9 @@ defmodule Spark.Dsl.Extension do
   end
 
   @doc false
-  def await_tasks(dsl) do
-    Task.await_many(dsl[:persist][:spark_compile_tasks] || [], :infinity)
-    %{dsl | persist: Map.delete(dsl.persist, :spark_compile_tasks)}
+  def await_persisted_compile_funs(dsl) do
+    await_compile_funs(dsl[:persist][:spark_compile_funs] || [])
+    %{dsl | persist: Map.delete(dsl.persist, :spark_compile_funs)}
   end
 
   def run_transformers(mod, transformers, spark_dsl_config, env) do
@@ -918,7 +918,7 @@ defmodule Spark.Dsl.Extension do
           end)
       end)
 
-      Spark.Dsl.Extension.await_all_tasks(agent)
+      Spark.Dsl.Extension.await_all_compile_funs(agent)
 
       Agent.stop(agent)
     end
@@ -2012,7 +2012,7 @@ defmodule Spark.Dsl.Extension do
   end
 
   @doc false
-  def await_all_tasks(agent) do
+  def await_all_compile_funs(agent) do
     Agent.get_and_update(
       agent,
       fn state ->
@@ -2021,7 +2021,7 @@ defmodule Spark.Dsl.Extension do
             {:stop, []}
 
           funs ->
-            {{:tasks, funs}, []}
+            {{:compile_funs, funs}, []}
         end
       end,
       :infinity
@@ -2030,27 +2030,25 @@ defmodule Spark.Dsl.Extension do
       :stop ->
         :ok
 
-      {:tasks, funs} ->
-        funs
-        |> Enum.map(&do_async_compile/1)
-        |> Task.await_many(:infinity)
+      {:compile_funs, funs} ->
+        await_compile_funs(funs)
 
-        await_all_tasks(agent)
+        await_all_compile_funs(agent)
     end
   end
 
   @doc false
-  def async_compile({agent, _pid}, func) do
+  def async_compile({agent, _pid}, fun) do
     if @parallel_compile do
       Agent.update(
         agent,
         fn funs ->
-          [func | funs]
+          [fun | funs]
         end,
         :infinity
       )
     else
-      func.()
+      fun.()
     end
   end
 
@@ -2072,13 +2070,17 @@ defmodule Spark.Dsl.Extension do
   end
 
   @doc false
-  def do_async_compile(fun) do
+  def await_compile_funs([]), do: []
+
+  def await_compile_funs(funs) do
     case :erlang.get(:elixir_compiler_info) do
       :undefined ->
-        Task.async(fun)
+        funs
+        |> Enum.map(&Task.async/1)
+        |> Task.await_many(:infinity)
 
       _ ->
-        Kernel.ParallelCompiler.async(fun)
+        Kernel.ParallelCompiler.pmap(funs, fn compile_fun -> compile_fun.() end)
     end
   end
 

--- a/lib/spark/dsl/transformer.ex
+++ b/lib/spark/dsl/transformer.ex
@@ -90,16 +90,14 @@ defmodule Spark.Dsl.Transformer do
   end
 
   @doc """
-  Runs the function in an async compiler.
+  Queues the function to run in an async compiler.
 
   Use this for compiling new modules and having them compiled
   efficiently asynchronously.
   """
   def async_compile(dsl, fun) do
-    task = Spark.Dsl.Extension.do_async_compile(fun)
-
-    tasks = get_persisted(dsl, :spark_compile_tasks, [])
-    persist(dsl, :spark_compile_tasks, [task | tasks])
+    funs = get_persisted(dsl, :spark_compile_funs, [])
+    persist(dsl, :spark_compile_funs, [fun | funs])
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Spark.MixProject do
     [
       app: :spark,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.16",
       elixirc_options: [
         warnings_as_errors: true,
         ignore_module_conflict: Mix.env() == :test,


### PR DESCRIPTION
🔥 The `pmap/2` born from Spark finally returns to Spark.

A [parallel compiler deadlock discovered in Spark](https://github.com/elixir-lang/elixir/issues/12897) led to the introduction of [`Kernel.ParallelCompiler.pmap/2`](https://github.com/elixir-lang/elixir/pull/12899) in Elixir 1.16.

Now that `Kernel.ParallelCompiler.async/1` is deprecated in Elixir 1.20, this PR raises Spark’s minimum Elixir version to 1.16 and moves its parallel compilation implementation to `pmap/2`.

The current main CI already runs on Elixir 1.20.0/OTP 28 and [fails because the `async/1` deprecation warning is treated as an error](https://github.com/ash-project/spark/actions/runs/30812537472/job/91682410102#step:8:320). This PR also updates the development and CI toolchain to Elixir 1.20.0/OTP 29.

- Raise the minimum supported Elixir version to 1.16
- Collect asynchronous compilation functions and execute them together with `Kernel.ParallelCompiler.pmap/2`
- Continue using `Task.async/1` and `Task.await_many/2` outside the compiler context
- Update the development and CI toolchain to Elixir 1.20.0/OTP 29

## Verification

- Elixir 1.16.3/OTP 26: `mix compile --force --warnings-as-errors`
- Elixir 1.16.3/OTP 26: `mix test` — 323 passed
- Elixir 1.20.0/OTP 29: `mix format --check-formatted`
- Elixir 1.20.0/OTP 29: `mix compile --force --warnings-as-errors`
- Elixir 1.20.0/OTP 29: `mix test` — 323 passed